### PR TITLE
✨ [Feature] friend request api

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint', 'import', 'prettier'],
-  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended', 'plugin:import/recommended'],
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:import/recommended'],
   root: true,
   env: {
     node: true,
@@ -19,6 +19,8 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
+    'prettier/prettier': 'error',
     'import/order': [
       'error',
       {

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
     'import/order': [
       'error',
       {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,7 @@
     "db": "docker compose --env-file .env -f ../docker-compose.yml up -d",
     "db:down": "docker compose --env-file .env -f ../docker-compose.yml down",
     "db:reset": "docker compose --env-file .env -f ../docker-compose.yml down -v",
-    "postinstall": "cd .. && husky install backend/.husky"
+    "postinstall": "if [ ! -d .husky/_ ]; then cd .. && husky install backend/.husky; fi"
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
@@ -32,6 +32,7 @@
     "@nestjs/serve-static": "^3.0.1",
     "@nestjs/swagger": "^6.3.0",
     "@nestjs/typeorm": "^9.0.1",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "pg": "^8.10.0",
     "postgresql": "^0.0.1",
@@ -44,7 +45,7 @@
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
-    "@nestjs/testing": "^9.0.0",
+    "@nestjs/testing": "^9.4.0",
     "@types/express": "^4.17.13",
     "@types/hapi__joi": "^17.1.9",
     "@types/jest": "29.2.4",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { AppConfigModule } from './config/app/configuration.module';
 import { DatabaseConfigModule } from './config/database/configuration.module';
 import { DatabaseConfigService } from './config/database/configuration.service';
+import { FriendModule } from './friend/friend.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { DatabaseConfigService } from './config/database/configuration.service';
       imports: [DatabaseConfigModule],
       useClass: DatabaseConfigService,
     }),
+    FriendModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/common/constant.ts
+++ b/backend/src/common/constant.ts
@@ -1,0 +1,5 @@
+/**
+ * @description: 상수 저장 파일
+ */
+
+export const FRIEND_LIMIT = 42;

--- a/backend/src/common/dto/error-response.dto.ts
+++ b/backend/src/common/dto/error-response.dto.ts
@@ -1,0 +1,19 @@
+export class ErrorResponseDto {
+  /**
+   * 에러 상태코드 (40x, 50x)
+   * @example 400
+   */
+  statusCode: number;
+
+  /**
+   * 에러 상세 메세지
+   * @example '요청이 처리되지 않았습니다.'
+   */
+  message: string;
+
+  /**
+   * 에러 코드 설명
+   * @example 'Not Found'
+   */
+  error: string;
+}

--- a/backend/src/common/dto/sucess-response.dto.ts
+++ b/backend/src/common/dto/sucess-response.dto.ts
@@ -1,0 +1,10 @@
+export class SuccessResponseDto {
+  constructor(readonly msg: string) {
+    this.message = msg;
+  }
+  /**
+   * 성공 응답 메세지
+   * @example '요청이 처리되었습니다.'
+   */
+  message: string;
+}

--- a/backend/src/entity/auth.entity.ts
+++ b/backend/src/entity/auth.entity.ts
@@ -1,6 +1,4 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
-
-import { User } from './user.entity';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 export enum AuthStatus {
   REGISTERD = 'REGISTERD',
@@ -12,7 +10,7 @@ export class Auth {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ length: 320 })
+  @Column({ length: 320, unique: true })
   email: string;
 
   @Column({ length: 320, nullable: true })

--- a/backend/src/entity/friendship.entity.ts
+++ b/backend/src/entity/friendship.entity.ts
@@ -1,8 +1,9 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
 import { User } from './user.entity';
 
 @Entity()
+@Unique(['sender', 'receiver'])
 export class Friendship {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/entity/message-view.entity.ts
+++ b/backend/src/entity/message-view.entity.ts
@@ -1,9 +1,10 @@
-import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryColumn, Unique } from 'typeorm';
 
 import { Friendship } from './friendship.entity';
 import { User } from './user.entity';
 
 @Entity()
+@Unique(['user', 'friend'])
 export class MessageView {
   @ManyToOne(() => User)
   @PrimaryColumn({ name: 'user_id' })

--- a/backend/src/entity/user.entity.ts
+++ b/backend/src/entity/user.entity.ts
@@ -9,7 +9,7 @@ export class User {
   @PrimaryColumn()
   id: number;
 
-  @Column({ length: 8 })
+  @Column({ length: 8, unique: true })
   nickname: string;
 
   @Column({ default: 0 })

--- a/backend/src/friend/friend.controller.spec.ts
+++ b/backend/src/friend/friend.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { FriendController } from './friend.controller';
+import { FriendService } from './friend.service';
+
+describe('FriendController', () => {
+  let controller: FriendController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FriendController],
+      providers: [FriendService],
+    }).compile();
+
+    controller = module.get<FriendController>(FriendController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -1,0 +1,63 @@
+import { Controller, Param, Post, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+
+import { FriendService } from './friend.service';
+
+@ApiTags('friend')
+@Controller('friend')
+export class FriendController {
+  constructor(private readonly friendService: FriendService) {}
+
+  //@Get()
+  //getFriends() {}
+
+  /**
+   * 친구 신청하기 (닉네임)
+   * @example { "nickname": "test" }
+
+   * @param nickname
+   * @returns
+   */
+  @ApiOkResponse({ description: '친구 신청을 보냈습니다.' })
+  @ApiQuery({ name: 'nickname', description: '친구 신청할 유저의 닉네임' })
+  @Post()
+  requestFriendByNickname(
+    @Query('nickname')
+    nickname: string,
+  ) {
+    const myId = 1;
+
+    return this.friendService.requestFriendByNickname(myId, nickname);
+  }
+
+  @ApiOkResponse({ description: '친구 신청을 보냈습니다.' })
+  @Post('/:userId')
+  requestFriend(@Param('userId') userId: number) {
+    // me to me 하면 어쩌지?
+    const myId = 1;
+
+    return this.friendService.requestFriend(myId, userId);
+  }
+
+  /*  @Delete('/:userId')
+  deleteFriend() {}
+
+  @Get('/request')
+  getFriendRequestList() {}
+
+  @Post('/accept/:userId')
+  acceptFriend() {}
+
+  @Post('/deny/:userId')
+  denyFriend() {}*/
+}
+
+/**
+ * 친구 신청 거절	POST	/friend/deny/{user_id}
+ * 친구 신청 수락	POST	/friend/accept/{user_id}
+ * 친구 끊기	DELETE	/friend/{user_id}
+ * 친구 신청하기 (id)	POST	/friend/{user_id}
+ * 친구 신청하기 (닉네임)	POST	/friend?nickname=””
+ * 친구 신청받은 리스트 가져오기	GET	/friend/request
+ * 친구 정보 리스트 가져오기	GET	/friend
+ */

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Friendship } from '../entity/friendship.entity';
+import { User } from '../entity/user.entity';
+
+import { FriendController } from './friend.controller';
+import { FriendService } from './friend.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Friendship, User])],
+  controllers: [FriendController],
+  providers: [FriendService],
+})
+export class FriendModule {}

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { Auth } from '../entity/auth.entity';
 import { Friendship } from '../entity/friendship.entity';
 import { User } from '../entity/user.entity';
 
@@ -8,7 +9,7 @@ import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, User])],
+  imports: [TypeOrmModule.forFeature([Friendship, Auth, User])],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/friend/friend.service.spec.ts
+++ b/backend/src/friend/friend.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { FriendService } from './friend.service';
+
+describe('FriendService', () => {
+  let service: FriendService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FriendService],
+    }).compile();
+
+    service = module.get<FriendService>(FriendService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -19,8 +19,7 @@ export class FriendService {
   async checkFriendCountLimit(userID: number): Promise<void> {
     const count = await this.friendshipRepository.count({
       where: {
-        sender: { id: userID },
-        accept: true,
+        receiver: { id: userID },
       },
     });
     if (count >= FRIEND_LIMIT) throw new ConflictException('친구 신청 정원이 꽉 찬 유저입니다.');

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -1,0 +1,91 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityNotFoundError, Repository } from 'typeorm';
+
+import { FRIEND_LIMIT } from '../common/constant';
+import { Friendship } from '../entity/friendship.entity';
+import { User } from '../entity/user.entity';
+
+@Injectable()
+export class FriendService {
+  constructor(
+    @InjectRepository(Friendship)
+    private readonly friendshipRepository: Repository<Friendship>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async checkFriendCountLimit(userID: number): Promise<void> {
+    const count = await this.friendshipRepository.count({
+      where: {
+        sender: { id: userID },
+        accept: true,
+      },
+    });
+    if (count >= FRIEND_LIMIT) throw new ConflictException('친구 신청 정원이 꽉 찬 유저입니다.');
+  }
+
+  async checkExistsFriendship(senderId: number, receiverId: number): Promise<void> {
+    const count = await this.friendshipRepository.count({
+      where: {
+        sender: { id: senderId },
+        receiver: { id: receiverId },
+      },
+    });
+    if (count !== 0) throw new ConflictException('이미 친구 신청을 보냈거나 친구인 유저입니다.');
+  }
+
+  async findUserNicknameById(id: number): Promise<string> {
+    // FIXME: Replace with UserService.
+    try {
+      return (
+        await this.userRepository.findOneOrFail({
+          select: ['nickname'],
+          where: { id: id },
+        })
+      ).nickname;
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) {
+        throw new NotFoundException('존재하지 않는 유저입니다.');
+      }
+      throw error;
+    }
+  }
+
+  async findUserIdByNickname(nickname: string): Promise<number> {
+    // FIXME: Replace with UserService.
+    try {
+      return (
+        await this.userRepository.findOneOrFail({
+          select: ['id'],
+          where: { nickname: nickname },
+        })
+      ).id;
+    } catch (error) {
+      throw error instanceof EntityNotFoundError ? new NotFoundException('존재하지 않는 유저입니다.') : error;
+    }
+  }
+
+  async requestFriendByNickname(senderId: number, nickname: string) {
+    const receiverId = await this.findUserIdByNickname(nickname);
+    return await this.requestFriend(senderId, receiverId);
+  }
+
+  /**
+   * id 로 FreindShip row 를 만든다.
+   * @param id 친구 신청할 유저의 id
+   */
+  async requestFriend(senderId: number, receiverId: number) {
+    await this.checkFriendCountLimit(receiverId);
+    await this.checkExistsFriendship(senderId, receiverId);
+
+    await this.friendshipRepository.insert({
+      sender: { id: senderId },
+      receiver: { id: receiverId },
+    });
+
+    return {
+      message: '친구 신청을 보냈습니다.',
+    };
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
@@ -6,6 +7,15 @@ import { AppConfigService } from './config/app/configuration.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  // validation pipe 를 global 으로 사용.
+  // (transform: true 는 DTO 에서 @IsNumber() 를 사용할 때, string 을 number 로 자동 변환해줌)
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('GhostPong API')

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -808,10 +808,10 @@
     path-to-regexp "3.2.0"
     swagger-ui-dist "4.18.2"
 
-"@nestjs/testing@^9.0.0":
-  version "9.3.12"
-  resolved "https://registry.yarnpkg.com/@nestjs/testing/-/testing-9.3.12.tgz#e02ed34c9a267ba9495ba7f5e3d83d4956e3414f"
-  integrity sha512-nH274IXEqU4hr4bcb71POe58hYLONt9RcfKKM5ZvOS7wYMnybMpKKR8DkC1WcfE1P2k2GQmQoHeSH5emPtYrBA==
+"@nestjs/testing@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/testing/-/testing-9.4.0.tgz#1e5d1e799413e996c9c2da02a89dfefa62c3b70e"
+  integrity sha512-xZWp363P4otcebg++gSjUcdCfTK0RorORzyFq3aLaSAQOlq8kxfFDRIKzEATR4aOUfqTMMsAA8lhnMJWf35N6A==
   dependencies:
     tslib "2.5.0"
 
@@ -1881,6 +1881,11 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
 
 class-validator@^0.14.0:
   version "0.14.0"


### PR DESCRIPTION
## Summary
- friend 도메인의 친구 신청 api 구현.
  - `POST /friend?nickname=`
  - `POST /friend/{userId}`
## Describe your changes
- 친구 신청하는 두 개의 api 컨트롤러와 서비스를 구현하였습니다.
- common/dto 에 모든 api 에서 사용하는 `SuccessResponseDto` 와 사실은 exception filter 에서 처리해서 리턴하기 떄문에 구현상에서는 필요없지만 swagger 에서 type 명시를 위해 사용하는 `ErrorResponseDto` 클래스를 정의했습니다. 
- auth 로직이 없기 때문에 "나의 id" 를 넣는 `x-my-id` 를 임시 헤더로 받도록 설정했습니다.
- 컨트롤러당 swagger 이것저것 설정.... 더 필요한 부분 있으면 연락주세용..
- entity 에 unique 설정 추가.
- eslint 에 규칙을 추가.
- validtation pipe 를 global 으로 설정하는 코드를 `main.ts` 에 추가.
## Issue number and link
- close #42 