### PR TITLE
✨ [Feature] friend get requests api

### DIFF
--- a/backend/src/common/dto/success-response.dto.ts
+++ b/backend/src/common/dto/success-response.dto.ts
@@ -1,5 +1,5 @@
 export class SuccessResponseDto {
-  constructor(readonly msg: string) {
+  constructor(msg: string) {
     this.message = msg;
   }
   /**

--- a/backend/src/friend/dto/requested-friend-response.dto.ts
+++ b/backend/src/friend/dto/requested-friend-response.dto.ts
@@ -1,0 +1,8 @@
+import { User } from '../../entity/user.entity';
+
+export class RequestedFriendResponseDto {
+  /**
+   * 친구 신청한 유저의 정보 배열
+   */
+  requests: User[];
+}

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import { Controller, Get, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiHeaders,
@@ -10,8 +10,9 @@ import {
 } from '@nestjs/swagger';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
-import { SuccessResponseDto } from '../common/dto/sucess-response.dto';
+import { SuccessResponseDto } from '../common/dto/success-response.dto';
 
+import { RequestedFriendResponseDto } from './dto/requested-friend-response.dto';
 import { FriendService } from './friend.service';
 
 @ApiTags('friend')
@@ -53,12 +54,17 @@ export class FriendController {
     return this.friendService.requestFriendById(myId, userId);
   }
 
+  @ApiOperation({ summary: '친구 신청받은 리스트 가져오기' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @Get('/request')
+  getFriendRequestList(@Headers('x-my-id') myId: number): Promise<RequestedFriendResponseDto> {
+    return this.friendService.getFriendRequestList(myId);
+  }
+
   /*  @Delete('/:userId')
   deleteFriend() {}
-
-  @Get('/request')
-  getFriendRequestList() {}
-
+*/
+  /*
   @Post('/accept/:userId')
   acceptFriend() {}
 

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -3,9 +3,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { EntityNotFoundError, Repository } from 'typeorm';
 
 import { FRIEND_LIMIT } from '../common/constant';
-import { SuccessResponseDto } from '../common/dto/sucess-response.dto';
+import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { Friendship } from '../entity/friendship.entity';
 import { User } from '../entity/user.entity';
+
+import { RequestedFriendResponseDto } from './dto/requested-friend-response.dto';
 
 @Injectable()
 export class FriendService {
@@ -87,5 +89,16 @@ export class FriendService {
       sender: { id: senderId },
       receiver: { id: receiverId },
     });
+  }
+
+  async getFriendRequestList(userId: number): Promise<RequestedFriendResponseDto> {
+    return {
+      requests: (
+        await this.friendshipRepository.find({
+          relations: ['sender'],
+          where: { receiver: { id: userId }, accept: false },
+        })
+      ).map((friendship) => friendship.sender),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- 받은 친구 신청 리스트를 가져오는 api 구현
## Describe your changes
- `GET /request` api 를 구현.
- `.map` 을 최대한 쓰고 싶지 않았는데.. typeORM 수준에서 `Friendship` 정보를 포함하지 않고 `User` 만 가져오기가 안됩니다...ㅋㅋㅋㅋㅋㅋ 자세한 것은 [위키](https://www.notion.so/TypeORM-dddebaecb5794479944454e1312fbf7d?pvs=4) 에 설명해두었습니다...
- `SuccessResponseDto` 가 있는 파일 명을 `success-response.dto.ts` 로 수정했습니다.
- 넘 자잘한 것 같아 다음 pr 은 친구 신청 수락 + 거절 합쳐서 하나로 만들어 날리도록 하겠습니다...!^^
## Issue number and link
close #57 