### PR TITLE
✨ [Feature] get user-meta-info api

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { AppConfigModule } from './config/app/configuration.module';
 import { DatabaseConfigModule } from './config/database/configuration.module';
 import { DatabaseConfigService } from './config/database/configuration.service';
 import { FriendModule } from './friend/friend.module';
+import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { FriendModule } from './friend/friend.module';
       useClass: DatabaseConfigService,
     }),
     FriendModule,
+    UserModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/user/dto/meta-info-response.dto.ts
+++ b/backend/src/user/dto/meta-info-response.dto.ts
@@ -1,0 +1,33 @@
+import { User } from '../../entity/user.entity';
+
+export class MetaInfoResponseDto {
+  constructor(user: User, numbers: number[]) {
+    this.nickname = user.nickname;
+    this.image = user.image;
+    this.exp = user.exp;
+    this.blockedUsers = numbers;
+  }
+  /**
+   * 현재 로그인한 유저의 닉네임
+   * @example 'san'
+   */
+  nickname: string;
+
+  /**
+   * 유저의 프로필 사진 url
+   * @example '/src/.../...'
+   */
+  image: string;
+
+  /**
+   * 유저의 경험치
+   * @example 42
+   */
+  exp: number;
+
+  /**
+   * 유저가 차단한 사람들의 id
+   * @example [23, 35, 82]
+   */
+  blockedUsers: number[];
+}

--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [UserService],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,0 +1,33 @@
+import { Controller } from '@nestjs/common';
+
+import { UserService } from './user.service';
+
+@Controller('user')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  // @Post()
+  // create(@Body() createUserDto: CreateUserDto) {
+  //   return this.userService.create(createUserDto);
+  // }
+
+  // @Get()
+  // findAll() {
+  //   return this.userService.findAll();
+  // }
+
+  // @Get(':id')
+  // findOne(@Param('id') id: string) {
+  //   return this.userService.findOne(+id);
+  // }
+
+  // @Patch(':id')
+  // update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+  //   return this.userService.update(+id, updateUserDto);
+  // }
+
+  // @Delete(':id')
+  // remove(@Param('id') id: string) {
+  //   return this.userService.remove(+id);
+  // }
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,11 +1,12 @@
-import { Controller, Get, Headers, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiHeaders, ApiNotFoundResponse, ApiOperation } from '@nestjs/swagger';
+import { Controller, Get, Headers } from '@nestjs/common';
+import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 
 import { MetaInfoResponseDto } from './dto/meta-info-response.dto';
 import { UserService } from './user.service';
 
+@ApiTags('user')
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
@@ -13,9 +14,8 @@ export class UserController {
   @ApiOperation({ summary: '유저 메타 정보 가져오기' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  @HttpCode(HttpStatus.OK)
   @Get()
-  requestMetaInfo(@Headers('x-my-id') myId: number): Promise<MetaInfoResponseDto> {
-    return this.userService.requestMetaInfo(myId);
+  getUserMetaInfo(@Headers('x-my-id') myId: number): Promise<MetaInfoResponseDto> {
+    return this.userService.getUserMetaInfo(myId);
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,33 +1,21 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Headers, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiHeaders, ApiNotFoundResponse, ApiOperation } from '@nestjs/swagger';
 
+import { ErrorResponseDto } from '../common/dto/error-response.dto';
+
+import { MetaInfoResponseDto } from './dto/meta-info-response.dto';
 import { UserService } from './user.service';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  // @Post()
-  // create(@Body() createUserDto: CreateUserDto) {
-  //   return this.userService.create(createUserDto);
-  // }
-
-  // @Get()
-  // findAll() {
-  //   return this.userService.findAll();
-  // }
-
-  // @Get(':id')
-  // findOne(@Param('id') id: string) {
-  //   return this.userService.findOne(+id);
-  // }
-
-  // @Patch(':id')
-  // update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-  //   return this.userService.update(+id, updateUserDto);
-  // }
-
-  // @Delete(':id')
-  // remove(@Param('id') id: string) {
-  //   return this.userService.remove(+id);
-  // }
+  @ApiOperation({ summary: '유저 메타 정보 가져오기' })
+  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @HttpCode(HttpStatus.OK)
+  @Get()
+  requestMetaInfo(@Headers('x-my-id') myId: number): Promise<MetaInfoResponseDto> {
+    return this.userService.requestMetaInfo(myId);
+  }
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+
+@Module({
+  controllers: [UserController],
+  providers: [UserService],
+})
+export class UserModule {}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { BlockedUser } from '../entity/blocked-user.entity';
+import { User } from '../entity/user.entity';
 
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User, BlockedUser])],
   controllers: [UserController],
   providers: [UserService],
 })

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,20 +1,47 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { BlockedUser } from '../entity/blocked-user.entity';
+import { User } from '../entity/user.entity';
+
+import { MetaInfoResponseDto } from './dto/meta-info-response.dto';
 
 @Injectable()
 export class UserService {
-  // create(createUserDto: CreateUserDto) {
-  //   return 'This action adds a new user';
-  // }
-  // findAll() {
-  //   return `This action returns all user`;
-  // }
-  // findOne(id: number) {
-  //   return `This action returns a #${id} user`;
-  // }
-  // update(id: number, updateUserDto: UpdateUserDto) {
-  //   return `This action updates a #${id} user`;
-  // }
-  // remove(id: number) {
-  //   return `This action removes a #${id} user`;
-  // }
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(BlockedUser)
+    private readonly blockedUserRepository: Repository<BlockedUser>,
+  ) {}
+
+  async requestMetaInfo(myId: number): Promise<MetaInfoResponseDto> {
+    const metaInfo = await this.findMetaInfoById(myId);
+    const numbers = await this.findBlockedByUserId(myId);
+    return new MetaInfoResponseDto(metaInfo, numbers);
+  }
+
+  async findMetaInfoById(userId: number): Promise<User> {
+    const user = await this.userRepository.findOne({
+      where: {
+        id: userId,
+      },
+    });
+    if (!user) throw new NotFoundException('존재하지 않는 유저입니다.');
+    return user;
+  }
+
+  async findBlockedByUserId(userId: number): Promise<number[]> {
+    const blockedList = await this.blockedUserRepository
+      .createQueryBuilder('blockedUser')
+      .select('blockedUser')
+      .where('blockedUser.userId = :id', { id: userId })
+      .getMany();
+    const numbers: number[] = [];
+    if (blockedList) {
+      blockedList.forEach((BlockedUser) => numbers.push(BlockedUser.blockedUserId));
+    }
+    return numbers;
+  }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -16,13 +16,13 @@ export class UserService {
     private readonly blockedUserRepository: Repository<BlockedUser>,
   ) {}
 
-  async requestMetaInfo(myId: number): Promise<MetaInfoResponseDto> {
-    const metaInfo = await this.findMetaInfoById(myId);
+  async getUserMetaInfo(myId: number): Promise<MetaInfoResponseDto> {
+    const metaInfo = await this.findUserById(myId);
     const numbers = await this.findBlockedByUserId(myId);
     return new MetaInfoResponseDto(metaInfo, numbers);
   }
 
-  async findMetaInfoById(userId: number): Promise<User> {
+  async findUserById(userId: number): Promise<User> {
     const user = await this.userRepository.findOne({
       where: {
         id: userId,
@@ -33,15 +33,10 @@ export class UserService {
   }
 
   async findBlockedByUserId(userId: number): Promise<number[]> {
-    const blockedList = await this.blockedUserRepository
-      .createQueryBuilder('blockedUser')
-      .select('blockedUser')
-      .where('blockedUser.userId = :id', { id: userId })
-      .getMany();
-    const numbers: number[] = [];
-    if (blockedList) {
-      blockedList.forEach((BlockedUser) => numbers.push(BlockedUser.blockedUserId));
-    }
-    return numbers;
+    return (
+      await this.blockedUserRepository.findBy({
+        userId: userId,
+      })
+    ).map((blockedUser) => blockedUser.blockedUserId);
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UserService {
+  // create(createUserDto: CreateUserDto) {
+  //   return 'This action adds a new user';
+  // }
+  // findAll() {
+  //   return `This action returns all user`;
+  // }
+  // findOne(id: number) {
+  //   return `This action returns a #${id} user`;
+  // }
+  // update(id: number, updateUserDto: UpdateUserDto) {
+  //   return `This action updates a #${id} user`;
+  // }
+  // remove(id: number) {
+  //   return `This action removes a #${id} user`;
+  // }
+}

--- a/database/test-data.sql
+++ b/database/test-data.sql
@@ -1,0 +1,30 @@
+-- user1
+INSERT INTO AUTH VALUES(1, 'aaaa@aaaa', NULL, 'UNREGISTERD');
+insert into USERS values(1, 'san', 42, 'asdfasdf');
+
+--user2
+INSERT INTO AUTH VALUES(2, 'asdf@aaaa', NULL, 'UNREGISTERD');
+insert into USERS values(2, 'jiskim', 11, 'asdf');
+
+-- user3
+INSERT INTO AUTH VALUES(3, 'qwee@aaaa', NULL, 'UNREGISTERD');
+insert into USERS values(3, 'hannkim', 22, 'qwer');
+
+-- user4
+INSERT INTO AUTH VALUES(4, 'erty@aaaa', NULL, 'UNREGISTERD');
+insert into USERS values(4, 'nkim', 33, 'erty');
+
+-- user5
+INSERT INTO AUTH VALUES(5, 'rtyu@aaaa', NULL, 'UNREGISTERD');
+insert into USERS values(5, 'seungsle', 44, 'rtyu');
+
+-- user6
+INSERT INTO AUTH VALUES(6, 'dfgh@aaaa', NULL, 'UNREGISTERD');
+insert into USERS values(6, 'yongjule', 55, 'dfgh');
+
+--
+-- blocked_user
+--
+insert into blocked_user VALUES(1, 6);
+insert into blocked_user VALUES(1, 5);
+insert into blocked_user VALUES(1, 4);


### PR DESCRIPTION
## Summary
- 로그인한 유저의 메타데이터 가져오는 API 구현

## Describe your changes
- `GET /user` api 구현
- typeORM 어렵네요... 일단 양식에 맞춰 blockedUser의 id, 즉 숫자 배열만 주기 위해서 QueryBuilder로 뽑은 엔티티에서 다시 필요한 id만 뽑아내는 로직을 넣었습니다. 만일 blocked 한 user가 없다면 빈배열을 주도록 의도했습니다. repository 제공 메서드이던 QueryBuilder이던 원하는 컬럼값만 예쁘게 뽑고 싶었는데 뭐로하던 객체로 한번 감싸서 나오더라구요....만일 원하는 컬러만 예쁘게 뽑아내는 법을 아신다면 제발 알려줍쇼....

- 아 그리고 편의를 위해 test용 db data를 넣는 sql문을 test-data.sql에 넣어놨습니다. 앞으로도 추가할 예정입니다. 참고하십쇼들!!!

## Issue number and link
close #61 