### PR TITLE
:sparkles: [Feature] block-user API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { BlockedModule } from './blocked/blocked.module';
 import { AppConfigModule } from './config/app/configuration.module';
 import { DatabaseConfigModule } from './config/database/configuration.module';
 import { DatabaseConfigService } from './config/database/configuration.service';
@@ -20,6 +21,7 @@ import { UserModule } from './user/user.module';
     FriendModule,
     UserModule,
     AuthModule,
+    BlockedModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/blocked/blocked.controller.spec.ts
+++ b/backend/src/blocked/blocked.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { BlockedController } from './blocked.controller';
+import { BlockedService } from './blocked.service';
+
+describe('BlockedController', () => {
+  let controller: BlockedController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BlockedController],
+      providers: [BlockedService],
+    }).compile();
+
+    controller = module.get<BlockedController>(BlockedController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,8 +1,22 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Headers, Post } from '@nestjs/common';
+import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiPreconditionFailedResponse, ApiTags } from '@nestjs/swagger';
+
+import { ErrorResponseDto } from '../common/dto/error-response.dto';
+import { SuccessResponseDto } from '../common/dto/success-response.dto';
 
 import { BlockedService } from './blocked.service';
 
+@ApiTags('blocked')
 @Controller('blocked')
 export class BlockedController {
   constructor(private readonly blockedService: BlockedService) {}
+
+  @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
+  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
+  @ApiPreconditionFailedResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @Post('blocked/:userId')
+  blockUserById(@Headers('x-my-id') myId: number, userId: number): Promise<SuccessResponseDto> {
+    return this.blockedService.blockUserById(myId, userId);
+  }
 }

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Headers, Param, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
+  ApiForbiddenResponse,
   ApiHeaders,
   ApiNotFoundResponse,
   ApiOperation,
@@ -21,9 +22,10 @@ export class BlockedController {
 
   @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
+  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
   @ApiConflictResponse({
     type: ErrorResponseDto,
-    description: '차단 목록 정원 다참, 이미 차단함 유저, 스스로를 차단할 수 없음',
+    description: '이미 차단함 유저, 스스로를 차단할 수 없음',
   })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
@@ -34,9 +36,10 @@ export class BlockedController {
 
   @ApiOperation({ summary: 'nickname으로 유저 차단하기(직접 입력)' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
+  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
   @ApiConflictResponse({
     type: ErrorResponseDto,
-    description: '차단 목록 정원 다참, 이미 차단함 유저, 스스로를 차단할 수 없음',
+    description: '이미 차단함 유저, 스스로를 차단할 수 없음',
   })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiQuery({ name: 'nickname', description: '차단할 유저 닉네임' })

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -3,7 +3,6 @@ import {
   ApiConflictResponse,
   ApiForbiddenResponse,
   ApiHeaders,
-  ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -21,12 +20,8 @@ export class BlockedController {
   constructor(private readonly blockedService: BlockedService) {}
 
   @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
-  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
   @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
-  @ApiConflictResponse({
-    type: ErrorResponseDto,
-    description: '이미 차단함 유저, 스스로를 차단할 수 없음',
-  })
+  @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 차단함 유저' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
   @HttpCode(HttpStatus.OK)
@@ -36,12 +31,8 @@ export class BlockedController {
   }
 
   @ApiOperation({ summary: 'nickname으로 유저 차단하기(직접 입력)' })
-  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
   @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
-  @ApiConflictResponse({
-    type: ErrorResponseDto,
-    description: '이미 차단함 유저, 스스로를 차단할 수 없음',
-  })
+  @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 차단한 유저' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiQuery({ name: 'nickname', description: '차단할 유저 닉네임' })
   @HttpCode(HttpStatus.OK)

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Headers, Param, Post, Query } from '@nestjs/common';
+import { Controller, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -29,6 +29,7 @@ export class BlockedController {
   })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
+  @HttpCode(HttpStatus.OK)
   @Post(':userId')
   blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
     return this.blockedService.blockUserById(+myId, +userId);
@@ -43,6 +44,7 @@ export class BlockedController {
   })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiQuery({ name: 'nickname', description: '차단할 유저 닉네임' })
+  @HttpCode(HttpStatus.OK)
   @Post()
   blockUserByNickname(
     @Headers('x-my-id') myId: number,

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+
+import { BlockedService } from './blocked.service';
+
+@Controller('blocked')
+export class BlockedController {
+  constructor(private readonly blockedService: BlockedService) {}
+}

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Headers, Post } from '@nestjs/common';
-import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiPreconditionFailedResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Headers, Param, Post } from '@nestjs/common';
+import { ApiConflictResponse, ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
@@ -13,10 +13,14 @@ export class BlockedController {
 
   @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
-  @ApiPreconditionFailedResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
+  @ApiConflictResponse({
+    type: ErrorResponseDto,
+    description: '차단 목록 정원 다참, 이미 차단함 유저, 스스로를 차단할 수 없음',
+  })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  @Post('blocked/:userId')
-  blockUserById(@Headers('x-my-id') myId: number, userId: number): Promise<SuccessResponseDto> {
-    return this.blockedService.blockUserById(myId, userId);
+  @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
+  @Post(':userId')
+  blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
+    return this.blockedService.blockUserById(+myId, +userId);
   }
 }

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,5 +1,13 @@
-import { Controller, Headers, Param, Post } from '@nestjs/common';
-import { ApiConflictResponse, ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Controller, Headers, Param, Post, Query } from '@nestjs/common';
+import {
+  ApiConflictResponse,
+  ApiHeaders,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
@@ -22,5 +30,21 @@ export class BlockedController {
   @Post(':userId')
   blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
     return this.blockedService.blockUserById(+myId, +userId);
+  }
+
+  @ApiOperation({ summary: 'nickname으로 유저 차단하기(직접 입력)' })
+  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
+  @ApiConflictResponse({
+    type: ErrorResponseDto,
+    description: '차단 목록 정원 다참, 이미 차단함 유저, 스스로를 차단할 수 없음',
+  })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @ApiQuery({ name: 'nickname', description: '차단할 유저 닉네임' })
+  @Post()
+  blockUserByNickname(
+    @Headers('x-my-id') myId: number,
+    @Query('nickname') nickname: string,
+  ): Promise<SuccessResponseDto> {
+    return this.blockedService.blockUserByNickname(+myId, nickname);
   }
 }

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlockedUser } from '../entity/blocked-user.entity';
+import { Friendship } from '../entity/friendship.entity';
 import { User } from '../entity/user.entity';
 import { UserService } from '../user/user.service';
 
@@ -9,7 +10,7 @@ import { BlockedController } from './blocked.controller';
 import { BlockedService } from './blocked.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlockedUser, User])],
+  imports: [TypeOrmModule.forFeature([BlockedUser, User, Friendship])],
   controllers: [BlockedController],
   providers: [BlockedService, UserService],
 })

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { BlockedController } from './blocked.controller';
+import { BlockedService } from './blocked.service';
+
+@Module({
+  controllers: [BlockedController],
+  providers: [BlockedService],
+})
+export class BlockedModule {}

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { BlockedUser } from '../entity/blocked-user.entity';
+import { User } from '../entity/user.entity';
+import { UserService } from '../user/user.service';
 
 import { BlockedController } from './blocked.controller';
 import { BlockedService } from './blocked.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([BlockedUser, User])],
   controllers: [BlockedController],
-  providers: [BlockedService],
+  providers: [BlockedService, UserService],
 })
 export class BlockedModule {}

--- a/backend/src/blocked/blocked.service.spec.ts
+++ b/backend/src/blocked/blocked.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { BlockedService } from './blocked.service';
+
+describe('BlockedService', () => {
+  let service: BlockedService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BlockedService],
+    }).compile();
+
+    service = module.get<BlockedService>(BlockedService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -1,4 +1,22 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { BlockedUser } from '../entity/blocked-user.entity';
+import { User } from '../entity/user.entity';
 
 @Injectable()
-export class BlockedService {}
+export class BlockedService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(BlockedUser)
+    private readonly blockedUserRepository: Repository<BlockedUser>,
+  ) {}
+
+  async blockUserById(myId: number, userId: number): Promise<SuccessResponseDto> {
+    await this.blockedUserRepository.insert({ userId: myId, blockedUserId: userId });
+    return new SuccessResponseDto('유저를 차단하였습니다.');
+  }
+}

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -1,22 +1,54 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { BLOCKED_USER_LIMIT } from '../common/constant';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { BlockedUser } from '../entity/blocked-user.entity';
-import { User } from '../entity/user.entity';
+import { UserService } from '../user/user.service';
 
 @Injectable()
 export class BlockedService {
   constructor(
-    @InjectRepository(User)
-    private readonly userRepository: Repository<User>,
     @InjectRepository(BlockedUser)
     private readonly blockedUserRepository: Repository<BlockedUser>,
+
+    private readonly userService: UserService,
   ) {}
 
   async blockUserById(myId: number, userId: number): Promise<SuccessResponseDto> {
+    if (myId === userId) {
+      throw new ConflictException('스스로를 미워하지 마십시오.');
+    }
+    await this.userService.findExistUser(userId);
+    await this.checkBlockedCountLimit(myId);
+    await this.checkExistBlockedUser(myId, userId);
     await this.blockedUserRepository.insert({ userId: myId, blockedUserId: userId });
     return new SuccessResponseDto('유저를 차단하였습니다.');
   }
+
+  /* 
+  validation check method
+  */
+
+  async checkBlockedCountLimit(userId: number): Promise<void> {
+    const count = await this.blockedUserRepository.countBy({ userId: userId });
+    if (count >= BLOCKED_USER_LIMIT) {
+      throw new ConflictException('차단 목록 정원이 찼습니다.');
+    }
+  }
+
+  async checkExistBlockedUser(userId: number, blockedUserId: number): Promise<void> {
+    const record = await this.blockedUserRepository.findOneBy({
+      userId: userId,
+      blockedUserId: blockedUserId,
+    });
+    if (record !== null) {
+      throw new NotFoundException('이미 차단한 유저입니다.');
+    }
+  }
+
+  /* 
+  repository method
+  */
 }

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -12,15 +12,23 @@ export class BlockedService {
   constructor(
     @InjectRepository(BlockedUser)
     private readonly blockedUserRepository: Repository<BlockedUser>,
-
     private readonly userService: UserService,
   ) {}
 
   async blockUserById(myId: number, userId: number): Promise<SuccessResponseDto> {
+    await this.userService.findExistUserById(userId);
+    return this.blockUser(myId, userId);
+  }
+
+  async blockUserByNickname(myId: number, nickname: string): Promise<SuccessResponseDto> {
+    const user = await this.userService.findExistUserByNickname(nickname);
+    return this.blockUser(myId, user.id);
+  }
+
+  async blockUser(myId: number, userId: number): Promise<SuccessResponseDto> {
     if (myId === userId) {
       throw new ConflictException('스스로를 미워하지 마십시오.');
     }
-    await this.userService.findExistUser(userId);
     await this.checkBlockedCountLimit(myId);
     await this.checkExistBlockedUser(myId, userId);
     await this.blockedUserRepository.insert({ userId: myId, blockedUserId: userId });

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -58,10 +58,7 @@ export class BlockedService {
         accept: true,
       },
     ]);
-    if (friendship !== null) {
-      return friendship;
-    }
-    return null;
+    return friendship;
   }
 
   /* 

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BlockedService {}

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -42,7 +42,7 @@ export class BlockedService {
   async checkBlockedCountLimit(userId: number): Promise<void> {
     const count = await this.blockedUserRepository.countBy({ userId: userId });
     if (count >= BLOCKED_USER_LIMIT) {
-      throw new ConflictException('차단 목록 정원이 찼습니다.');
+      throw new ForbiddenException('차단 목록 정원이 찼습니다.');
     }
   }
 

--- a/backend/src/common/constant.ts
+++ b/backend/src/common/constant.ts
@@ -3,4 +3,5 @@
  */
 
 export const FRIEND_LIMIT = 42;
+export const BLOCKED_USER_LIMIT = 42;
 export const DEFAULT_IMAGE = 'images/default_image.png';

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -30,19 +30,15 @@ export class UserService {
   }
 
   async findExistUserById(userId: number): Promise<User> {
-    const user = await this.userRepository.findOneBy({
-      id: userId,
-    });
+    const user = await this.userRepository.findOneBy({ id: userId });
     if (user === null) {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
     return user;
   }
 
-  async findExistUserByNickname(userNickname: string): Promise<User> {
-    const user = await this.userRepository.findOneBy({
-      nickname: userNickname,
-    });
+  async findExistUserByNickname(nickname: string): Promise<User> {
+    const user = await this.userRepository.findOneBy({ nickname: nickname });
     if (user === null) {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
@@ -50,10 +46,8 @@ export class UserService {
   }
 
   async findBlockedByUserId(userId: number): Promise<number[]> {
-    return (
-      await this.blockedUserRepository.findBy({
-        userId: userId,
-      })
-    ).map((blockedUser) => blockedUser.blockedUserId);
+    return (await this.blockedUserRepository.findBy({ userId: userId })).map(
+      (blockedUser) => blockedUser.blockedUserId,
+    );
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -18,20 +18,30 @@ export class UserService {
   ) {}
 
   async getUserInfo(myId: number): Promise<UserInfoResponseDto> {
-    const userInfo = await this.findExistUser(myId);
+    const userInfo = await this.findExistUserById(myId);
     const numbers = await this.findBlockedByUserId(myId);
     return new UserInfoResponseDto(userInfo, numbers);
   }
 
   async updateProfileImage(myId: number, imageUrl: string): Promise<SuccessResponseDto> {
-    await this.findExistUser(myId);
+    await this.findExistUserById(myId);
     await this.userRepository.update({ id: myId }, { image: imageUrl });
     return new SuccessResponseDto('이미지 변경 완료되었습니다.');
   }
 
-  async findExistUser(userId: number): Promise<User> {
+  async findExistUserById(userId: number): Promise<User> {
     const user = await this.userRepository.findOneBy({
       id: userId,
+    });
+    if (user === null) {
+      throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
+    return user;
+  }
+
+  async findExistUserByNickname(userNickname: string): Promise<User> {
+    const user = await this.userRepository.findOneBy({
+      nickname: userNickname,
     });
     if (user === null) {
       throw new NotFoundException('존재하지 않는 유저입니다.');


### PR DESCRIPTION
## Summary
유저를 차단하는 API 구현

## Describe your changes
두 api에 대한 로직이 매우 흡사하여 한번에 pr 합니다.
 
- `blocked/{user_id}` 구현
- userService에 구현한 findExistUser를 가져다 썼습니다. 그런데 nickname으로 찾아올때도 같은 일을 하는 함수가 필요해서 By를 붙여 구분하였습니다. 
- `blocked?nickname=""` 구현

- 만든 함수들 이름이 좀 긴데 줄이기엔 애매해서 그냥 놔두었습니다.

## Issue number and link
- close #78 
- close #79 