### PR TITLE
✨ [Feature] get friend list API

### DIFF
--- a/backend/src/entity/friendship.entity.ts
+++ b/backend/src/entity/friendship.entity.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
+import { MessageView } from './message-view.entity';
 import { User } from './user.entity';
 
 @Entity()
@@ -21,4 +22,7 @@ export class Friendship {
     default: () => "'-infinity'",
   })
   lastMessegeTime: Date;
+
+  @OneToMany(() => MessageView, (messageView) => messageView.friend)
+  messageView: MessageView[];
 }

--- a/backend/src/entity/message-view.entity.ts
+++ b/backend/src/entity/message-view.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryColumn, Unique } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryColumn, Relation, Unique } from 'typeorm';
 
 import { Friendship } from './friendship.entity';
 import { User } from './user.entity';
@@ -10,9 +10,9 @@ export class MessageView {
   @PrimaryColumn({ name: 'user_id' })
   user: User;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => Friendship)
   @PrimaryColumn({ name: 'friend_id' })
-  friend: Friendship;
+  friend: Relation<Friendship>;
 
   @Column({ default: () => "'-infinity'" })
   lastViewTime: Date;

--- a/backend/src/friend/dto/friend-response.dto.ts
+++ b/backend/src/friend/dto/friend-response.dto.ts
@@ -1,0 +1,13 @@
+import { User } from '../../entity/user.entity';
+
+class FriendInformation extends User {
+  lastMessegeTime: Date | null;
+  lastViewTime: Date | null;
+}
+
+export class FriendsResponseDto {
+  /**
+   * 친구의 정보 배열
+   */
+  friends: FriendInformation[];
+}

--- a/backend/src/friend/dto/requested-friend-response.dto.ts
+++ b/backend/src/friend/dto/requested-friend-response.dto.ts
@@ -1,6 +1,6 @@
 import { User } from '../../entity/user.entity';
 
-export class RequestedFriendResponseDto {
+export class RequestedFriendsResponseDto {
   /**
    * 친구 신청한 유저의 정보 배열
    */

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -13,7 +13,8 @@ import {
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 
-import { RequestedFriendResponseDto } from './dto/requested-friend-response.dto';
+import { FriendsResponseDto } from './dto/friend-response.dto';
+import { RequestedFriendsResponseDto } from './dto/requested-friend-response.dto';
 import { FriendService } from './friend.service';
 
 @ApiTags('friend')
@@ -21,8 +22,12 @@ import { FriendService } from './friend.service';
 export class FriendController {
   constructor(private readonly friendService: FriendService) {}
 
-  //@Get()
-  //getFriends() {}
+  @ApiOperation({ summary: '친구 리스트 가져오기' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @Get()
+  getFriendsList(@Headers('x-my-id') myId: number): Promise<FriendsResponseDto> {
+    return this.friendService.getFriendsList(+myId);
+  }
 
   // TODO : validtaion pipe 추가..
   @ApiOperation({ summary: '친구 신청하기 (닉네임)' })
@@ -43,8 +48,8 @@ export class FriendController {
   @ApiOperation({ summary: '친구 신청받은 리스트 가져오기' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @Get('request')
-  getFriendRequestList(@Headers('x-my-id') myId: number): Promise<RequestedFriendResponseDto> {
-    return this.friendService.getFriendRequestList(+myId);
+  getFriendRequestsList(@Headers('x-my-id') myId: number): Promise<RequestedFriendsResponseDto> {
+    return this.friendService.getFriendRequestsList(+myId);
   }
 
   @ApiOperation({ summary: '친구 신청하기 (id)' })

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Auth } from '../entity/auth.entity';
 import { Friendship } from '../entity/friendship.entity';
+import { MessageView } from '../entity/message-view.entity';
 import { User } from '../entity/user.entity';
 
 import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, Auth, User])],
+  imports: [TypeOrmModule.forFeature([Friendship, Auth, User, MessageView])],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -74,6 +74,7 @@ export class FriendService {
             { sender: { id: userId }, accept: true },
             { receiver: { id: userId }, accept: true },
           ],
+          order: { lastMessegeTime: 'DESC' },
         })
       ).map(({ sender, receiver, lastMessegeTime, messageView }) => {
         // messgeView 가 없으면 (find() 가 undefined 이면) null
@@ -141,7 +142,6 @@ export class FriendService {
         await this.friendshipRepository.find({
           relations: ['sender'],
           where: { receiver: { id: userId }, accept: false },
-          order: { lastMessegeTime: 'DESC' },
         })
       ).map((friendship) => friendship.sender),
     };

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -76,7 +76,7 @@ export class FriendService {
           ],
         })
       ).map(({ sender, receiver, lastMessegeTime, messageView }) => {
-        // messgeView 가 없으면 (find() 가 undefined null
+        // messgeView 가 없으면 (find() 가 undefined 이면) null
         const lastViewTime = messageView.find((view) => view.user.id === userId)?.lastViewTime || null;
         return {
           ...(sender.id === userId ? receiver : sender),
@@ -98,7 +98,6 @@ export class FriendService {
     }
   }
 
-  // FIXME :  2 -> 3 있으면 3 -> 2 도 안돼야 하는데 돌아감
   async requestFriendById(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
     // FIXME : pipe 로 로직 바꾸기
     if (senderId === receiverId) {

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -98,6 +98,12 @@ export class FriendService {
     }
   }
 
+  /**
+   *
+   * @param senderId 신청 보내는 유저 : 나
+   * @param receiverId 신청 받는 유저 : 상대방
+   * @returns
+   */
   async requestFriendById(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
     // FIXME : pipe 로 로직 바꾸기
     if (senderId === receiverId) {


### PR DESCRIPTION
## Summary
- `GET /friend` API 구현
## Describe your changes
- `MessageView` 와 `Friendship` 간 순환참조를 해결하기 위해 `Relation<T>` 로 엔티티를 수정했습니다. [TypeORM 문서 참고](https://typeorm.io/faq#how-to-use-typeorm-in-esm-projects)
  - 다른 entity 에서도 타입이 정의되지 않아서 어쩌구...  하는 순환참조 같아보이는 문제가 나면 이 해결방법이 도움이 될 것 같습니다.
- `-infinity` (`lastViewTime` 과 `lastMessageTime` 의 기본값) 이 select 했을 때 `null` 로 오길래 메세지 기록이 없어서 `lastMessageTime` 이 `-infinity` 이고 join 했을 때의 `messegeView` 가 없을 경우 `lastViewTime` 을 `null` 로 설정했습니다.
## Issue number and link
- close #83 