### PR TITLE
✨ [Feature] delete friend api

### DIFF
--- a/backend/seeding/data-source.ts
+++ b/backend/seeding/data-source.ts
@@ -1,4 +1,3 @@
-//import dotenv
 import { config } from 'dotenv';
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';

--- a/backend/seeding/seeder/message.seeder.ts
+++ b/backend/seeding/seeder/message.seeder.ts
@@ -17,7 +17,6 @@ export default async (dataSource: DataSource) => {
 
   const authRepository: Repository<Auth> = dataSource.getRepository(Auth);
   const auths = await authRepository.save(Array(Number(process.argv[2])).fill(null).map(authFactory));
-  //const auths = await factoryManager.get(Auth).saveMany(Number(process.argv[2]));
   console.log('auth ' + auths.length + ' rows created.');
   fs.mkdir(resultDir, () => {
     fs.writeFile(path.join(resultDir, 'auths.json'), JSON.stringify(auths), (err) => {
@@ -68,9 +67,10 @@ export default async (dataSource: DataSource) => {
       }
     });
 
+  // insert 할 양이 많으면 error 가 발생하므로 100개씩 나눠서 insert
   const promises = [];
-  for (let i = 0; i < messageSeed.length; i += 10) {
-    promises.push(messageRepository.save(messageSeed.slice(i, i + 10)));
+  for (let i = 0; i < messageSeed.length; i += 100) {
+    promises.push(messageRepository.save(messageSeed.slice(i, i + 100)));
   }
   const messages = await Promise.all(promises);
 

--- a/backend/src/entity/message-view.entity.ts
+++ b/backend/src/entity/message-view.entity.ts
@@ -10,7 +10,7 @@ export class MessageView {
   @PrimaryColumn({ name: 'user_id' })
   user: User;
 
-  @ManyToOne(() => Friendship)
+  @ManyToOne(() => Friendship, { onDelete: 'CASCADE' })
   @PrimaryColumn({ name: 'friend_id' })
   friend: Relation<Friendship>;
 

--- a/backend/src/entity/message.entity.ts
+++ b/backend/src/entity/message.entity.ts
@@ -11,7 +11,7 @@ export class Message {
   @ManyToOne(() => User)
   sender: User;
 
-  @ManyToOne(() => Friendship)
+  @ManyToOne(() => Friendship, { onDelete: 'CASCADE' })
   friend: Friendship;
 
   @Column({ length: 512 })

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import { Controller, Delete, Get, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -63,6 +63,12 @@ export class FriendController {
     return this.friendService.requestFriendById(+myId, userId);
   }
 
+  @ApiOperation({ summary: '친구 삭제하기' })
+  @Delete(':userId')
+  deleteFriend(@Param('userId') userId: number, @Headers('x-my-id') myId: number): Promise<SuccessResponseDto> {
+    return this.friendService.deleteFriend(+myId, userId);
+  }
+
   @ApiOperation({ summary: '친구 신청 수락하기' })
   @ApiForbiddenResponse({ type: ErrorResponseDto, description: '친구 정원 초과' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
@@ -81,9 +87,4 @@ export class FriendController {
     // FIXME: myId 임시 헤더라서 + 갈겼습니다...
     return this.friendService.rejectFriendRequest(userId, +myId);
   }
-
-  /*
-  @Delete(':userId')
-  deleteFriend() {}
-  */
 }

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -5,12 +5,13 @@ import { Auth } from '../entity/auth.entity';
 import { Friendship } from '../entity/friendship.entity';
 import { MessageView } from '../entity/message-view.entity';
 import { User } from '../entity/user.entity';
+import { UserModule } from '../user/user.module';
 
 import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, Auth, User, MessageView])],
+  imports: [TypeOrmModule.forFeature([Friendship, Auth, User, MessageView]), UserModule],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -85,8 +85,6 @@ export class FriendService {
     if (senderId === receiverId) {
       throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
     }
-    // check receiver exists
-    await this.userService.findExistUserById(receiverId);
     // 친구 신청 혹은 친구 관계가 있는 지 확인. 하나라도 있으면 error 이므로 findOneBy.
     const friendship = await this.friendshipRepository.findOneBy([
       { sender: { id: senderId }, receiver: { id: receiverId } }, // sender -> receiver
@@ -97,6 +95,7 @@ export class FriendService {
         friendship.accept ? '이미 친구인 유저입니다.' : '이미 친구 신청을 보냈거나 받은 유저입니다.',
       );
     }
+    await this.checkFriendLimit(senderId, '나');
     await this.checkFriendLimit(receiverId, '상대방');
     await this.checkFriendRequestLimit(receiverId);
 

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -228,7 +228,7 @@ export class FriendService {
     if (senderId === receiverId) {
       throw new BadRequestException('스스로를 거부하지 마십시오...');
     }
-    await this.friendshipRepository.remove(await this.findExistFriendRequest(senderId, receiverId));
+    await this.friendshipRepository.delete((await this.findExistFriendRequest(senderId, receiverId)).id);
     return new SuccessResponseDto('친구 신청을 거절했습니다.');
   }
   // !SECTION public

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -11,7 +11,6 @@ import { Repository } from 'typeorm';
 import { FRIEND_LIMIT } from '../common/constant';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { Friendship } from '../entity/friendship.entity';
-import { User } from '../entity/user.entity';
 import { UserService } from '../user/user.service';
 
 import { FriendsResponseDto } from './dto/friend-response.dto';
@@ -22,12 +21,12 @@ export class FriendService {
   constructor(
     @InjectRepository(Friendship)
     private readonly friendshipRepository: Repository<Friendship>,
-    @InjectRepository(User)
     private readonly userService: UserService,
   ) {}
 
   // SECTION: private
   /**
+   * 친구 정원이 꽉 찼는지 확인한다.
    *
    * @param userId 친구 수를 체크할 유저
    * @param userType 유저의 타입 ( 나 or 상대방 )
@@ -43,13 +42,25 @@ export class FriendService {
     }
   }
 
+  /**
+   * 친구 신청 정원이 꽉 찼는지 확인한다.
+   *
+   * @param userId 친구 신청 수를 체크할 유저
+   */
   private async checkFriendRequestLimit(userId: number): Promise<void> {
     if ((await this.friendshipRepository.countBy({ receiver: { id: userId }, accept: false })) >= FRIEND_LIMIT) {
       throw new ForbiddenException('친구 신청 정원이 꽉 찬 유저입니다.');
     }
   }
 
-  private async getFriendship(senderId: number, receiverId: number): Promise<Friendship> {
+  /**
+   * sender -> receiver 로 보낸 친구 신청이 있는지 확인하고 반환.
+   *
+   * @param senderId 보낸 사람
+   * @param receiverId 받은 사람
+   * @returns sender 가 receiver 에게 보낸 친구 신청 정보
+   */
+  private async findExistFriendRequest(senderId: number, receiverId: number): Promise<Friendship> {
     const friendship = await this.friendshipRepository.findOneBy({
       sender: { id: senderId },
       receiver: { id: receiverId },
@@ -63,9 +74,48 @@ export class FriendService {
     return friendship;
   }
 
+  /**
+   * 친구 신청을 보낸다.
+   *
+   * @param senderId 보내는 유저 (나)
+   * @param receiverId 신청 받는 유저 (상대방)
+   * @returns
+   */
+  private async requestFriend(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
+    if (senderId === receiverId) {
+      throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
+    }
+    // check receiver exists
+    await this.userService.findExistUserById(receiverId);
+    // 친구 신청 혹은 친구 관계가 있는 지 확인. 하나라도 있으면 error 이므로 findOneBy.
+    const friendship = await this.friendshipRepository.findOneBy([
+      { sender: { id: senderId }, receiver: { id: receiverId } }, // sender -> receiver
+      { sender: { id: receiverId }, receiver: { id: senderId } }, // receiver -> sender
+    ]);
+    if (friendship !== null) {
+      throw new ConflictException(
+        friendship.accept ? '이미 친구인 유저입니다.' : '이미 친구 신청을 보냈거나 받은 유저입니다.',
+      );
+    }
+    await this.checkFriendLimit(receiverId, '상대방');
+    await this.checkFriendRequestLimit(receiverId);
+
+    await this.friendshipRepository.insert({
+      sender: { id: senderId },
+      receiver: { id: receiverId },
+    });
+    return new SuccessResponseDto('친구 신청을 보냈습니다.');
+  }
+
   // !SECTION private
 
   // SECTION: public
+  /**
+   * 친구 목록을 가져온다.
+   *
+   * @param userId 친구 목록을 가져올 유저의 id (내 id)
+   * @returns 친구 목록
+   */
   async getFriendsList(userId: number): Promise<FriendsResponseDto> {
     return {
       friends: (
@@ -90,41 +140,27 @@ export class FriendService {
   }
 
   async requestFriendByNickname(senderId: number, nickname: string): Promise<SuccessResponseDto> {
-    return this.requestFriendById(senderId, (await this.userService.findExistUserByNickname(nickname)).id);
+    return this.requestFriend(senderId, (await this.userService.findExistUserByNickname(nickname)).id);
   }
 
   /**
+   * id 로 친구 신청
    *
    * @param senderId 신청 보내는 유저 : 나
    * @param receiverId 신청 받는 유저 : 상대방
    * @returns
    */
   async requestFriendById(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
-    // FIXME : pipe 로 로직 바꾸기
-    if (senderId === receiverId) {
-      throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
-    }
-    // check receiver exists
     await this.userService.findExistUserById(receiverId);
-    const friendship = await this.friendshipRepository.findOneBy([
-      { sender: { id: senderId }, receiver: { id: receiverId } }, // sender -> receiver
-      { sender: { id: receiverId }, receiver: { id: senderId } }, // receiver -> sender
-    ]);
-    if (friendship !== null) {
-      throw new ConflictException(
-        friendship.accept ? '이미 친구인 유저입니다.' : '이미 친구 신청을 보냈거나 받은 유저입니다.',
-      );
-    }
-    await this.checkFriendLimit(receiverId, '상대방');
-    await this.checkFriendRequestLimit(receiverId);
-
-    await this.friendshipRepository.insert({
-      sender: { id: senderId },
-      receiver: { id: receiverId },
-    });
-    return new SuccessResponseDto('친구 신청을 보냈습니다.');
+    return this.requestFriend(senderId, receiverId);
   }
 
+  /**
+   * 친구 신청받은 목록을 가져온다.
+   *
+   * @param userId
+   * @returns
+   */
   async getFriendRequestsList(userId: number): Promise<RequestedFriendsResponseDto> {
     return {
       requests: (
@@ -137,6 +173,31 @@ export class FriendService {
   }
 
   /**
+   * 친구 관계 삭제
+   *
+   * @param senderId
+   * @param receiverId
+   * @returns
+   */
+  async deleteFriend(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
+    // FIXME : pipe 로 로직 바꾸기
+    if (senderId === receiverId) {
+      throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
+    }
+
+    const friendship = await this.friendshipRepository.findOneBy([
+      { sender: { id: senderId }, receiver: { id: receiverId }, accept: true },
+      { sender: { id: receiverId }, receiver: { id: senderId }, accept: true },
+    ]);
+    if (friendship === null) {
+      throw new NotFoundException('친구 관계가 존재하지 않습니다.');
+    }
+    await this.friendshipRepository.delete(friendship.id);
+    return new SuccessResponseDto('친구를 삭제했습니다.');
+  }
+
+  /**
+   * 친구 신청 수락
    *
    * @param senderId 신청을 보내놓은 유저 : 상대방
    * @param receiverId 신청을 받은 유저 : 나
@@ -148,14 +209,15 @@ export class FriendService {
       throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
     }
 
-    const friendship = await this.getFriendship(senderId, receiverId);
-    await this.checkFriendLimit(receiverId, '나'); // 내 친구 42명 넘음
-    await this.checkFriendLimit(senderId, '상대방'); //상대의 친구 42명 넘음
+    const friendship = await this.findExistFriendRequest(senderId, receiverId);
+    await this.checkFriendLimit(receiverId, '나');
+    await this.checkFriendLimit(senderId, '상대방');
     await this.friendshipRepository.update({ id: friendship.id }, { accept: true });
     return new SuccessResponseDto('친구 추가 되었습니다.');
   }
 
   /**
+   * 친구 신청 거절
    *
    * @param senderId 신청을 보내놓은 유저 : 상대방
    * @param receiverId 신청을 받은 유저 : 나
@@ -166,7 +228,7 @@ export class FriendService {
     if (senderId === receiverId) {
       throw new BadRequestException('스스로를 거부하지 마십시오...');
     }
-    await this.friendshipRepository.delete({ id: (await this.getFriendship(senderId, receiverId)).id });
+    await this.friendshipRepository.remove(await this.findExistFriendRequest(senderId, receiverId));
     return new SuccessResponseDto('친구 신청을 거절했습니다.');
   }
   // !SECTION public

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -11,5 +11,6 @@ import { UserService } from './user.service';
   imports: [TypeOrmModule.forFeature([User, BlockedUser])],
   controllers: [UserController],
   providers: [UserService],
+  exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
## Summary
- `DELETE /friend/userId` 구현
- FriendService 메소드들에 주석 추가
## Describe your changes
-  `requestFriendByNickname` -> `requestFriendById` 호출하던 구조에서 중복 체크가 있어서 `requestFriend` 라는 공통 메소드를 만들고 `private` 으로 뺐습니다.
- friendship 이 삭제될 때 연결된 message 도 삭제되어야 하므로 `onDelete: cascade` 옵션을 `message.entity.ts` 에 추가했습니다.
  - 근데 생각해보니 `messageView` 에도 있어야 할 옵션 같아서 적다가 추가했습니다.ㅎㅎ
- `getFriendship` 을 `findExistFriendRequest` 로 더 정확하게 명명했습니다. `accept: false` 인 레코드만 가져옵니다.
- 지난 pr 에서 `blockService` 에서 쓰는 `friendRepository` 부분을 `friendService` 로 빼달라고 하셨는데 friend 에서는 친구관계가 없을 때 에러를 던져버리고 block 에서는 없어도 아무일이 없어야해서 validation 로직까지 빼기가 좀 애매합니다...
`friendship` 을 find 하는 부분만 메소드가 되어버릴텐데 그러면 repository 를 직접 사용하는 것과 다른 점이 없는 것 같아 일단 놔뒀습니다.
## Issue number and link
- close #82 