### PR TITLE
✨ [Feature] delete block user API

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -9,8 +9,8 @@ import { AuthService } from './auth.service';
 @Module({
   // 사용할 entity
   imports: [TypeOrmModule.forFeature([Auth])],
-  providers: [AuthService],
   controllers: [AuthController],
+  providers: [AuthService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -11,5 +11,6 @@ import { AuthService } from './auth.service';
   imports: [TypeOrmModule.forFeature([Auth])],
   providers: [AuthService],
   controllers: [AuthController],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -46,7 +46,7 @@ export class BlockedController {
   }
 
   @ApiOperation({ summary: '유저 차단한거 해제하기' })
-  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '차단한 적이 없는 유저, 존재하지 않는 유저' })
+  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '차단한 기록이 없는 유저, 존재하지 않는 유저' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '차단 해제할 사람 아이디' })
   @Delete(':userId')

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -45,7 +45,7 @@ export class BlockedController {
     return this.blockedService.blockUserByNickname(+myId, nickname);
   }
 
-  @ApiOperation({ summary: '유저 차단한거 해제하기' })
+  @ApiOperation({ summary: '유저 차단 해제' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '차단한 기록이 없는 유저, 존재하지 않는 유저' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '차단 해제할 사람 아이디' })

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import { Controller, Delete, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
   ApiHeaders,
+  ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -42,5 +43,14 @@ export class BlockedController {
     @Query('nickname') nickname: string,
   ): Promise<SuccessResponseDto> {
     return this.blockedService.blockUserByNickname(+myId, nickname);
+  }
+
+  @ApiOperation({ summary: '유저 차단한거 해제하기' })
+  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '차단한 적이 없는 유저, 존재하지 않는 유저' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @ApiParam({ name: 'userId', description: '차단 해제할 사람 아이디' })
+  @Delete(':userId')
+  deleteBlockedUser(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
+    return this.blockedService.deleteBlockedUser(+myId, userId);
   }
 }

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -3,15 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlockedUser } from '../entity/blocked-user.entity';
 import { Friendship } from '../entity/friendship.entity';
-import { User } from '../entity/user.entity';
-import { UserService } from '../user/user.service';
+import { UserModule } from '../user/user.module';
 
 import { BlockedController } from './blocked.controller';
 import { BlockedService } from './blocked.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlockedUser, User, Friendship])],
+  imports: [TypeOrmModule.forFeature([BlockedUser, Friendship]), UserModule],
   controllers: [BlockedController],
-  providers: [BlockedService, UserService],
+  providers: [BlockedService],
 })
 export class BlockedModule {}

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlockedUser } from '../entity/blocked-user.entity';
@@ -9,8 +9,9 @@ import { BlockedController } from './blocked.controller';
 import { BlockedService } from './blocked.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlockedUser, Friendship]), UserModule],
+  imports: [TypeOrmModule.forFeature([BlockedUser, Friendship]), forwardRef(() => UserModule)],
   controllers: [BlockedController],
   providers: [BlockedService],
+  exports: [BlockedService],
 })
 export class BlockedModule {}

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -57,7 +57,7 @@ export class BlockedService {
     await this.userService.findExistUserById(userId);
     const blockedUser = await this.blockedUserRepository.findOneBy({ userId: myId, blockedUserId: userId });
     if (blockedUser === null) {
-      throw new NotFoundException('차단한 적이 없는 유저입니다.');
+      throw new NotFoundException('차단된 유저가 아닙니다.');
     }
     await this.blockedUserRepository.delete(blockedUser);
     return new SuccessResponseDto('차단 해제 되었습니다.');

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -58,7 +58,7 @@ export class BlockedService {
     if (blockedUser === null) {
       throw new NotFoundException('차단 기록이 없습니다.');
     }
-    await this.blockedUserRepository.delete(blockedUser);
+    await this.blockedUserRepository.delete({ userId: blockedUser.userId, blockedUserId: blockedUser.blockedUserId });
     return new SuccessResponseDto('차단 해제 되었습니다.');
   }
 

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -95,7 +95,7 @@ export class BlockedService {
   /* 
   repository method
   */
-  async findBlockedIdByUserId(userId: number): Promise<number[]> {
+  async findBlockedId(userId: number): Promise<number[]> {
     return (await this.blockedUserRepository.findBy({ userId: userId })).map(
       (blockedUser) => blockedUser.blockedUserId,
     );

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -54,10 +54,9 @@ export class BlockedService {
     if (myId === userId) {
       throw new ConflictException('본인 자신은 차단되어 있지 않습니다!!!');
     }
-    await this.userService.findExistUserById(userId);
     const blockedUser = await this.blockedUserRepository.findOneBy({ userId: myId, blockedUserId: userId });
     if (blockedUser === null) {
-      throw new NotFoundException('차단된 유저가 아닙니다.');
+      throw new NotFoundException('차단한 기록이 없습니다.');
     }
     await this.blockedUserRepository.delete(blockedUser);
     return new SuccessResponseDto('차단 해제 되었습니다.');

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -96,7 +96,7 @@ export class BlockedService {
   /* 
   repository method
   */
-  async findBlockedByUserId(userId: number): Promise<number[]> {
+  async findBlockedIdByUserId(userId: number): Promise<number[]> {
     return (await this.blockedUserRepository.findBy({ userId: userId })).map(
       (blockedUser) => blockedUser.blockedUserId,
     );

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -1,4 +1,11 @@
-import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  forwardRef,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -15,6 +22,7 @@ export class BlockedService {
     private readonly blockedUserRepository: Repository<BlockedUser>,
     @InjectRepository(Friendship)
     private readonly friendshipRepository: Repository<Friendship>,
+    @Inject(forwardRef(() => UserService))
     private readonly userService: UserService,
   ) {}
 
@@ -57,7 +65,8 @@ export class BlockedService {
 
   /* 
     TODO: friend 도메인으로 옮기면 좋을 것 같은 메서드들 
-    */
+  */
+
   async checkIsFriend(myId: number, userId: number): Promise<Friendship | null> {
     const friendship = await this.friendshipRepository.findOneBy([
       { sender: { id: myId }, receiver: { id: userId }, accept: true },
@@ -87,4 +96,9 @@ export class BlockedService {
   /* 
   repository method
   */
+  async findBlockedByUserId(userId: number): Promise<number[]> {
+    return (await this.blockedUserRepository.findBy({ userId: userId })).map(
+      (blockedUser) => blockedUser.blockedUserId,
+    );
+  }
 }

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -56,7 +56,7 @@ export class BlockedService {
     }
     const blockedUser = await this.blockedUserRepository.findOneBy({ userId: myId, blockedUserId: userId });
     if (blockedUser === null) {
-      throw new NotFoundException('차단한 기록이 없습니다.');
+      throw new NotFoundException('차단 기록이 없습니다.');
     }
     await this.blockedUserRepository.delete(blockedUser);
     return new SuccessResponseDto('차단 해제 되었습니다.');

--- a/backend/src/entity/user.entity.ts
+++ b/backend/src/entity/user.entity.ts
@@ -4,12 +4,6 @@ import { Auth } from './auth.entity';
 
 @Entity({ name: 'users' })
 export class User {
-  constructor(id: number, nickname: string, image: string) {
-    this.id = id;
-    this.nickname = nickname;
-    this.image = image;
-  }
-
   @OneToOne(() => Auth, (auth) => auth.id)
   @JoinColumn({ name: 'id' }) // necessary for one-to-one relationship
   @PrimaryColumn()

--- a/backend/src/entity/user.entity.ts
+++ b/backend/src/entity/user.entity.ts
@@ -4,6 +4,12 @@ import { Auth } from './auth.entity';
 
 @Entity({ name: 'users' })
 export class User {
+  constructor(id: number, nickname: string, image: string) {
+    this.id = id;
+    this.nickname = nickname;
+    this.image = image;
+  }
+
   @OneToOne(() => Auth, (auth) => auth.id)
   @JoinColumn({ name: 'id' }) // necessary for one-to-one relationship
   @PrimaryColumn()

--- a/backend/src/user/dto/nickname-request.dto.ts
+++ b/backend/src/user/dto/nickname-request.dto.ts
@@ -8,6 +8,6 @@ export class NicknameRequestDto {
   @IsNotEmpty()
   @IsString()
   @MaxLength(8)
-  @Matches(RegExp('^[가-힣a-zA-Z0-9]*$'))
+  @Matches('/^[가-힣a-zA-Z0-9]*$/')
   nickname: string;
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { AuthService } from '../auth/auth.service';
+import { AuthModule } from '../auth/auth.module';
 import { Auth } from '../entity/auth.entity';
 import { BlockedUser } from '../entity/blocked-user.entity';
 import { User } from '../entity/user.entity';
@@ -10,9 +10,9 @@ import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, BlockedUser, Auth])],
+  imports: [TypeOrmModule.forFeature([User, BlockedUser, Auth]), AuthModule],
   controllers: [UserController],
-  providers: [UserService, AuthService],
+  providers: [UserService],
   exports: [UserService],
 })
 export class UserModule {}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,16 +1,15 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '../auth/auth.module';
-import { Auth } from '../entity/auth.entity';
-import { BlockedUser } from '../entity/blocked-user.entity';
+import { BlockedModule } from '../blocked/blocked.module';
 import { User } from '../entity/user.entity';
 
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, BlockedUser, Auth]), AuthModule],
+  imports: [TypeOrmModule.forFeature([User]), AuthModule, forwardRef(() => BlockedModule)],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -23,7 +23,7 @@ export class UserService {
 
   async getUserInfo(myId: number): Promise<UserInfoResponseDto> {
     const userInfo = await this.findExistUserById(myId);
-    const numbers = await this.blockedService.findBlockedByUserId(myId);
+    const numbers = await this.blockedService.findBlockedIdByUserId(myId);
     return new UserInfoResponseDto(userInfo, numbers);
   }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -43,10 +43,8 @@ export class UserService {
     await this.authService.checkExistAuthId(authId);
     await this.checkAlreadyExistUser(authId);
     await this.checkDuplicatedNickname(nickname);
-
     await this.userRepository.manager.transaction(async (manager: EntityManager) => {
-      const user = new User(authId, nickname, DEFAULT_IMAGE);
-      await manager.save(user);
+      await manager.insert(User, { id: authId, nickname: nickname, image: DEFAULT_IMAGE });
       await this.authService.changeAuthStatus(authId);
     });
     return new NicknameResponseDto(nickname);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -23,7 +23,7 @@ export class UserService {
 
   async getUserInfo(myId: number): Promise<UserInfoResponseDto> {
     const userInfo = await this.findExistUserById(myId);
-    const numbers = await this.blockedService.findBlockedIdByUserId(myId);
+    const numbers = await this.blockedService.findBlockedId(myId);
     return new UserInfoResponseDto(userInfo, numbers);
   }
 


### PR DESCRIPTION
## Summary
차단한 유저를 해제하는 API 구현

## Describe your changes
- `/blocked/(user_id)` 구현

- 다른 레포지토리를 사용할 때 우선은 레포지토리는 본인(A) 도메인 레포지토리만 사용하고 남(B)의 레포지토리는  BService를 가져다가 사용하도록 했는데요. 이때 import 하는 범위를 현재는 Module로 하고 있습니다. 계속 module을 import 받아 BService를 사용하는 방식으로 진행할지 아니면 그냥 import 없이 BRepository를 가져다 쓸지는 각 방법의 장단점을 _**좀 더 공부해보고 위키 작성 후 리팩토링하도록 하겠습니다.**_    아무튼 현재는 모듈을 import 받고 BService(남의 서비스 클래스)를 가져다가 사용하는 방식으로 진행하겠습니다. 

- 두 모듈간의 순환 참조에 대해서도 우선 서버가 돌아가도록 두개 모두 forwardRef() 처리를 해놓고 자세한 이유는 _**더 공부해서 위키에 적도록 하겠습니다.**_ 

- createUser() in UserService에서 transaction 처리 해놨습니다. 

## Issue number and link
- close #106 