### PR TITLE
✨ [Feature] get messages API

### DIFF
--- a/backend/seeding/factory/message.factory.ts
+++ b/backend/seeding/factory/message.factory.ts
@@ -6,9 +6,9 @@ import { Friendship } from '../../src/entity/friendship.entity';
 
 export default (friendship: Friendship) => {
   return {
-    sender: faker.datatype.boolean() ? friendship.sender : friendship.receiver,
-    friend: friendship,
-    contents: faker.lorem.sentence(),
+    senderId: faker.datatype.boolean() ? friendship.sender.id : friendship.receiver.id,
+    friendId: friendship.id,
+    content: faker.lorem.sentence(),
     createdAt: faker.date.past(1, friendship.lastMessegeTime),
   };
 };

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppConfigModule } from './config/app/configuration.module';
 import { DatabaseConfigModule } from './config/database/configuration.module';
 import { DatabaseConfigService } from './config/database/configuration.service';
 import { FriendModule } from './friend/friend.module';
+import { MessageModule } from './message/message.module';
 import { UserModule } from './user/user.module';
 
 @Module({
@@ -18,10 +19,11 @@ import { UserModule } from './user/user.module';
       imports: [DatabaseConfigModule],
       useClass: DatabaseConfigService,
     }),
-    FriendModule,
-    UserModule,
     AuthModule,
     BlockedModule,
+    FriendModule,
+    MessageModule,
+    UserModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/common/constant.ts
+++ b/backend/src/common/constant.ts
@@ -2,6 +2,9 @@
  * @description: 상수 저장 파일
  */
 
-export const FRIEND_LIMIT = 42;
-export const BLOCKED_USER_LIMIT = 42;
-export const DEFAULT_IMAGE = 'images/default_image.png';
+const FRIEND_LIMIT = 42;
+const BLOCKED_USER_LIMIT = 42;
+const DEFAULT_IMAGE = 'images/default_image.png';
+const MESSAGE_SIZE_PER_PAGE = 20;
+
+export { FRIEND_LIMIT, BLOCKED_USER_LIMIT, DEFAULT_IMAGE, MESSAGE_SIZE_PER_PAGE };

--- a/backend/src/entity/message.entity.ts
+++ b/backend/src/entity/message.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Friendship } from './friendship.entity';
 import { User } from './user.entity';
@@ -8,15 +8,23 @@ export class Message {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => User)
-  sender: User;
+  @Column()
+  senderId: number;
 
-  @ManyToOne(() => Friendship, { onDelete: 'CASCADE' })
-  friend: Friendship;
+  @Column()
+  friendId: number;
 
   @Column({ length: 512 })
-  contents: string;
+  content: string;
 
   @Column({ default: () => 'now()' })
   createdAt: Date;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  sender: User;
+
+  @ManyToOne(() => Friendship, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  friend: Friendship;
 }

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { Auth } from '../entity/auth.entity';
 import { Friendship } from '../entity/friendship.entity';
 import { MessageView } from '../entity/message-view.entity';
 import { User } from '../entity/user.entity';
@@ -11,7 +10,7 @@ import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, Auth, User, MessageView]), UserModule],
+  imports: [TypeOrmModule.forFeature([Friendship, User, MessageView]), UserModule],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/message/dto/message-response.dto.ts
+++ b/backend/src/message/dto/message-response.dto.ts
@@ -1,10 +1,32 @@
-type MessageInfo = {
+class MessageInfo {
+  /**
+   * 메시지 아이디
+   * @example 1
+   */
   id: number;
+
+  /**
+   * 메시지 보낸 사람 아이디
+   * @example 1
+   */
   senderId: number;
+
+  /**
+   * 메세지 내용
+   * @example '안녕하세요'
+   */
   content: string;
+
+  /**
+   * 메세지 보낸 시간
+   * @example '2021-08-01T00:00:00.000Z'
+   */
   createdAt: Date;
-};
+}
 
 export class MessageResponseDto {
+  /**
+   * 메시지 리스트 (32개)
+   */
   messages: MessageInfo[];
 }

--- a/backend/src/message/dto/message-response.dto.ts
+++ b/backend/src/message/dto/message-response.dto.ts
@@ -1,0 +1,10 @@
+type MessageInfo = {
+  id: number;
+  senderId: number;
+  content: string;
+  createdAt: Date;
+};
+
+export class MessageResponseDto {
+  messages: MessageInfo[];
+}

--- a/backend/src/message/message.controller.spec.ts
+++ b/backend/src/message/message.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { MessageController } from './message.controller';
+import { MessageService } from './message.service';
+
+describe('MessageController', () => {
+  let controller: MessageController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MessageController],
+      providers: [MessageService],
+    }).compile();
+
+    controller = module.get<MessageController>(MessageController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
-import { ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, Query, Headers } from '@nestjs/common';
+import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 
@@ -13,10 +13,15 @@ export class MessageController {
 
   @ApiOperation({ summary: '메시지 리스트 가져오기' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '친구 관계 없음 (친구 삭제됨)' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'friendId', required: true, description: '대화 나누는 상대 친구와의 friendship의 id' })
   @ApiQuery({ name: 'offset', required: false, description: '마지막으로 가져온 메시지의 id' })
   @Get(':friendId')
-  getMessagesList(@Param('friendId') friendId: number, @Query('offset') offset: number): Promise<MessageResponseDto> {
-    return this.messageService.getMessagesList(friendId, offset);
+  getMessagesList(
+    @Param('friendId') friendId: number,
+    @Query('offset') offset: number,
+    @Headers('x-my-id') myId: number,
+  ): Promise<MessageResponseDto> {
+    return this.messageService.getMessagesList(myId, friendId, offset);
   }
 }

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+
+import { ErrorResponseDto } from '../common/dto/error-response.dto';
+
+import { MessageResponseDto } from './dto/message-response.dto';
+import { MessageService } from './message.service';
+
+@ApiTags('message')
+@Controller('message')
+export class MessageController {
+  constructor(private readonly messageService: MessageService) {}
+
+  @ApiOperation({ summary: '메시지 리스트 가져오기' })
+  @ApiNotFoundResponse({ type: ErrorResponseDto, description: '친구 관계 없음 (친구 삭제됨)' })
+  @ApiParam({ name: 'friendId', required: true, description: '대화 나누는 상대 친구와의 friendship의 id' })
+  @ApiQuery({ name: 'offset', required: false, description: '마지막으로 가져온 메시지의 id' })
+  @Get(':friendId')
+  getMessagesList(@Param('friendId') friendId: number, @Query('offset') offset: number): Promise<MessageResponseDto> {
+    return this.messageService.getMessagesList(friendId, offset);
+  }
+}

--- a/backend/src/message/message.module.ts
+++ b/backend/src/message/message.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Friendship } from '../entity/friendship.entity';
+import { Message } from '../entity/message.entity';
+
+import { MessageController } from './message.controller';
+import { MessageService } from './message.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Friendship, Message])],
+  controllers: [MessageController],
+  providers: [MessageService],
+})
+export class MessageModule {}

--- a/backend/src/message/message.service.spec.ts
+++ b/backend/src/message/message.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { MessageService } from './message.service';
+
+describe('MessageService', () => {
+  let service: MessageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MessageService],
+    }).compile();
+
+    service = module.get<MessageService>(MessageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/message/message.service.ts
+++ b/backend/src/message/message.service.ts
@@ -18,16 +18,18 @@ export class MessageService {
   ) {}
 
   /**
+   * 메시지 리스트 가져오메
    *
+   * @param myId 내 아이디
    * @param friendId 친구와의 friendship의 id
    * @param offset 마지막으로 가져온 메시지의 id
    */
-  async getMessagesList(friendId: number, offset: number): Promise<MessageResponseDto> {
+  async getMessagesList(myId: number, friendId: number, offset: number): Promise<MessageResponseDto> {
     const friendship = await this.friendshipRepository.findOneBy([{ id: friendId, accept: true }]);
     if (friendship === null) {
       throw new NotFoundException('친구 관계가 없습니다.');
     }
-    if (friendship.sender.id !== friendId && friendship.receiver.id !== friendId) {
+    if (friendship.sender.id !== myId && friendship.receiver.id !== myId) {
       throw new ForbiddenException('친구 관계에 속한 유저가 아닙니다.');
     }
     return {

--- a/backend/src/message/message.service.ts
+++ b/backend/src/message/message.service.ts
@@ -1,0 +1,42 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+
+import { MESSAGE_SIZE_PER_PAGE } from '../common/constant';
+import { Friendship } from '../entity/friendship.entity';
+import { Message } from '../entity/message.entity';
+
+import { MessageResponseDto } from './dto/message-response.dto';
+
+@Injectable()
+export class MessageService {
+  constructor(
+    @InjectRepository(Message)
+    private readonly messageRepository: Repository<Message>,
+    @InjectRepository(Friendship)
+    private readonly friendshipRepository: Repository<Friendship>,
+  ) {}
+
+  /**
+   *
+   * @param friendId 친구와의 friendship의 id
+   * @param offset 마지막으로 가져온 메시지의 id
+   */
+  async getMessagesList(friendId: number, offset: number): Promise<MessageResponseDto> {
+    const friendship = await this.friendshipRepository.findOneBy([{ id: friendId, accept: true }]);
+    if (friendship === null) {
+      throw new NotFoundException('친구 관계가 없습니다.');
+    }
+    if (friendship.sender.id !== friendId && friendship.receiver.id !== friendId) {
+      throw new ForbiddenException('친구 관계에 속한 유저가 아닙니다.');
+    }
+    return {
+      messages: await this.messageRepository.find({
+        select: ['id', 'senderId', 'content', 'createdAt'],
+        where: { friendId, id: isNaN(offset) ? undefined : LessThan(offset) },
+        order: { createdAt: 'DESC' },
+        take: MESSAGE_SIZE_PER_PAGE, // max limit of entities that should be taken
+      }),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- `offset` 과 `friendID` 로 메세지를 32개씩 가져오는 `GET /message/friendId?offset=` api 구현
## Describe your changes
- message 를 가져올 때 불필요한 join 및 select 의 어려움으로 `Message` 엔티티를 변경했습니다. 자세한 변경점과 효과는 노션의 백엔드 위키에 [Join 이 필요없는 entity 의 property 분리](https://www.notion.so/Join-entity-property-dc6cd87ac9f24daabe31c07b24b2a2d7?pvs=4) 참고 바랍니다.
- entity 의 변경으로 seeding 파일에도 변경점이 있습니다.
- 변경된 entity 로 메세지를 32 개씩 가져오는 `getMessageList` 로직을 구현했습니다. `cursor` 가 오지 않을 경우 `undefined` 인 점을 이용해서 아름답게 처리해보려고 했으나 global 로 설정된 `validationPipe` 덕분에 `number` 로 `transform` 되면서 `NaN`이 되어버려.. 그냥 `isNaN` 을 사용해서 처리해줬습니다.
## Issue number and link
- close #22 