### PR TITLE
🐛  [BugFix] Fix seeding for all host and port

### DIFF
--- a/backend/seeding/data-source.ts
+++ b/backend/seeding/data-source.ts
@@ -19,6 +19,8 @@ config();
 (async () => {
   if (process.argv[2] === undefined) {
     console.log('Please enter the number of auths to be created.');
+    console.log('ex) yarn seed 300\n');
+    process.exit(1);
   }
 
   const options: DataSourceOptions = {

--- a/backend/seeding/reset-db.sh
+++ b/backend/seeding/reset-db.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 DB=$(grep "TEST_DB_NAME" .env | cut -d "=" -f 2)
-dropdb $DB -f 2>/dev/null; createdb $DB;
+HOST=$(grep "DB_HOST" .env | cut -d "=" -f 2)
+PORT=$(grep "DB_PORT" .env | cut -d "=" -f 2)
+USER=$(grep "DB_USER" .env | cut -d "=" -f 2)
+psql -p $PORT -h $HOST -d postgres -U $USER -c "drop database $DB" -c "create database $DB"
+
 rm -rf seeding/results;


### PR DESCRIPTION

## Summary
- yarn seed:reset 시 env 파일에 대응하도록 수정

## Describe your changes
- `dropdb` 와 `createdb` 대신 `psql -c` 로 직접 쿼리실행
- 도커에서 사용할 경우를 위해 host, port, user 지정해서 사용하도록 변경. 

## Issue number and link
- close #134 