### PR TITLE
✨ [Feature] enhancing friend and blocked API

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -20,8 +20,4 @@ export class AuthService {
       throw new ConflictException('이미 등록된 유저입니다.');
     }
   }
-
-  async changeAuthStatus(authId: number): Promise<void> {
-    await this.authRepository.update({ id: authId }, { status: AuthStatus.REGISTERD });
-  }
 }

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -20,16 +20,11 @@ import { BlockedUserResponseDto } from './dto/blocked-user-response.dto';
 @Controller('blocked')
 export class BlockedController {
   constructor(private readonly blockedService: BlockedService) {}
-
-  @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
-  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
-  @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 차단함 유저' })
+  @ApiOperation({ summary: '차단한 유저 목록(정보 포함) 가져오기' })
+  @Get()
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
-  @HttpCode(HttpStatus.OK)
-  @Post(':userId')
-  blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
-    return this.blockedService.blockUserById(+myId, +userId);
+  getBlockedUserList(@Headers('x-my-id') myId: number): Promise<BlockedUserResponseDto> {
+    return this.blockedService.getBlockedUserList(+myId);
   }
 
   @ApiOperation({ summary: 'nickname으로 유저 차단하기(직접 입력)' })
@@ -46,6 +41,17 @@ export class BlockedController {
     return this.blockedService.blockUserByNickname(+myId, nickname);
   }
 
+  @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
+  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
+  @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 차단한 유저' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
+  @HttpCode(HttpStatus.OK)
+  @Post(':userId')
+  blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
+    return this.blockedService.blockUserById(+myId, +userId);
+  }
+
   @ApiOperation({ summary: '유저 차단 해제' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '차단한 기록이 없는 유저, 존재하지 않는 유저' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
@@ -53,12 +59,5 @@ export class BlockedController {
   @Delete(':userId')
   deleteBlockedUser(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
     return this.blockedService.deleteBlockedUser(+myId, userId);
-  }
-
-  @ApiOperation({ summary: '차단한 유저 목록(정보 포함) 가져오기' })
-  @Get()
-  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  getBlockedUserList(@Headers('x-my-id') myId: number): Promise<BlockedUserResponseDto> {
-    return this.blockedService.getBlockedUserList(+myId);
   }
 }

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -2,14 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlockedUser } from '../entity/blocked-user.entity';
-import { Friendship } from '../entity/friendship.entity';
 import { UserModule } from '../user/user.module';
 
 import { BlockedController } from './blocked.controller';
 import { BlockedService } from './blocked.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlockedUser, Friendship]), UserModule],
+  imports: [TypeOrmModule.forFeature([BlockedUser]), UserModule],
   controllers: [BlockedController],
   providers: [BlockedService],
   exports: [BlockedService],

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -29,7 +29,7 @@ export class BlockedService {
       throw new BadRequestException('스스로를 미워하지 마십시오.');
     }
     await this.checkBlockedCountLimit(myId);
-    if ((await this.findBlockedUser(myId, userId)) === null) {
+    if ((await this.findBlockedUser(myId, userId)) !== null) {
       throw new ConflictException('이미 차단한 유저입니다.');
     }
     await this.blockUserAndDeleteFriendships(myId, userId);
@@ -101,7 +101,7 @@ export class BlockedService {
         .where('friendship.receiver_id = :userId AND friendship.sender_id = :blockedUserId', { userId, blockedUserId })
         .orWhere('friendship.sender_id = :userId AND friendship.receiver_id= :blockedUserId', { userId, blockedUserId })
         .execute();
-      await manager.insert(BlockedUser, { userId: userId, blockedUserId: blockedUserId });
+      await manager.insert('blocked_user', { userId: userId, blockedUserId: blockedUserId });
     });
   }
 }

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -28,10 +28,10 @@ export class BlockedService {
     if (myId === userId) {
       throw new BadRequestException('스스로를 미워하지 마십시오.');
     }
-    await this.checkBlockedCountLimit(myId);
     if ((await this.findBlockedUser(myId, userId)) !== null) {
       throw new ConflictException('이미 차단한 유저입니다.');
     }
+    await this.checkBlockedCountLimit(myId);
     await this.blockUserAndDeleteFriendships(myId, userId);
     return new SuccessResponseDto('유저를 차단하였습니다.');
   }

--- a/backend/src/entity/friendship.entity.ts
+++ b/backend/src/entity/friendship.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
 import { MessageView } from './message-view.entity';
 import { User } from './user.entity';
@@ -9,10 +9,18 @@ export class Friendship {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column()
+  senderId: number;
+
+  @Column()
+  receiverId: number;
+
   @ManyToOne(() => User)
+  @JoinColumn()
   sender: User;
 
   @ManyToOne(() => User)
+  @JoinColumn()
   receiver: User;
 
   @Column({ default: false })

--- a/backend/src/friend/dto/friend-response.dto.ts
+++ b/backend/src/friend/dto/friend-response.dto.ts
@@ -1,8 +1,29 @@
 import { User } from '../../entity/user.entity';
 
-class FriendInformation extends User {
+class FriendInformation {
+  /**
+   * 친구 관계 아이디 (나와 상대방의 friendship id)
+   * @example 1
+   */
+  friendId: number;
+
+  /**
+   * 마지막으로 메세지를 주고 받은 시간
+   * @example '2021-08-01T00:00:00.000Z'
+   */
   lastMessegeTime: Date | null;
+
+  /**
+   * 마지막으로 메세지를 읽은 시간 (나)
+   * @example '2021-08-01T00:00:00.000Z'
+   */
   lastViewTime: Date | null;
+
+  /**
+   * 친구의 유저 정보
+   * @example { id: 1, nickname: 'san1', profileImage: '/asset/profile-1.jpg', exp: 0 }
+   */
+  user: User;
 }
 
 export class FriendsResponseDto {

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -53,7 +53,7 @@ export class FriendController {
   }
 
   @ApiOperation({ summary: '친구 신청하기 (id)' })
-  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '친구 신청 정원 초과, 친구 정원 초과' })
+  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 관계, 친구 신청 정원 초과, 친구 정원 초과' })
   @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 친구 상태, 이미 친구 신청 상태' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '친구 신청할 유저의 아이디' })

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { BlockedModule } from '../blocked/blocked.module';
 import { Friendship } from '../entity/friendship.entity';
 import { MessageView } from '../entity/message-view.entity';
 import { User } from '../entity/user.entity';
@@ -10,7 +11,7 @@ import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, User, MessageView]), UserModule],
+  imports: [TypeOrmModule.forFeature([Friendship, User, MessageView]), UserModule, BlockedModule],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -1,17 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { BlockedModule } from '../blocked/blocked.module';
+import { BlockedUser } from '../entity/blocked-user.entity';
 import { Friendship } from '../entity/friendship.entity';
 import { MessageView } from '../entity/message-view.entity';
-import { User } from '../entity/user.entity';
 import { UserModule } from '../user/user.module';
 
 import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, User, MessageView]), UserModule, BlockedModule],
+  imports: [TypeOrmModule.forFeature([Friendship, BlockedUser, MessageView]), UserModule],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { BlockedService } from '../blocked/blocked.service';
 import { FRIEND_LIMIT } from '../common/constant';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { Friendship } from '../entity/friendship.entity';
@@ -22,91 +23,8 @@ export class FriendService {
     @InjectRepository(Friendship)
     private readonly friendshipRepository: Repository<Friendship>,
     private readonly userService: UserService,
+    private readonly blockedService: BlockedService,
   ) {}
-
-  // SECTION: private
-  /**
-   * 친구 정원이 꽉 찼는지 확인한다.
-   *
-   * @param userId 친구 수를 체크할 유저
-   * @param userType 유저의 타입 ( 나 or 상대방 )
-   */
-  private async checkFriendLimit(userId: number, userType: string): Promise<void> {
-    if (
-      (await this.friendshipRepository.countBy([
-        { receiver: { id: userId }, accept: true },
-        { sender: { id: userId }, accept: true },
-      ])) >= FRIEND_LIMIT
-    ) {
-      throw new ForbiddenException(`${userType}의 친구 정원이 꽉 찼습니다.`);
-    }
-  }
-
-  /**
-   * 친구 신청 정원이 꽉 찼는지 확인한다.
-   *
-   * @param userId 친구 신청 수를 체크할 유저
-   */
-  private async checkFriendRequestLimit(userId: number): Promise<void> {
-    if ((await this.friendshipRepository.countBy({ receiver: { id: userId }, accept: false })) >= FRIEND_LIMIT) {
-      throw new ForbiddenException('친구 신청 정원이 꽉 찬 유저입니다.');
-    }
-  }
-
-  /**
-   * sender -> receiver 로 보낸 친구 신청이 있는지 확인하고 반환.
-   *
-   * @param senderId 보낸 사람
-   * @param receiverId 받은 사람
-   * @returns sender 가 receiver 에게 보낸 친구 신청 정보
-   */
-  private async findExistFriendRequest(senderId: number, receiverId: number): Promise<Friendship> {
-    const friendship = await this.friendshipRepository.findOneBy({
-      sender: { id: senderId },
-      receiver: { id: receiverId },
-    });
-    if (friendship === null) {
-      throw new NotFoundException('존재하지 않는 친구 신청입니다.');
-    }
-    if (friendship.accept === true) {
-      throw new ConflictException('이미 친구인 유저입니다.');
-    }
-    return friendship;
-  }
-
-  /**
-   * 친구 신청을 보낸다.
-   *
-   * @param senderId 보내는 유저 (나)
-   * @param receiverId 신청 받는 유저 (상대방)
-   * @returns
-   */
-  private async requestFriend(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
-    if (senderId === receiverId) {
-      throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
-    }
-    // 친구 신청 혹은 친구 관계가 있는 지 확인. 하나라도 있으면 error 이므로 findOneBy.
-    const friendship = await this.friendshipRepository.findOneBy([
-      { sender: { id: senderId }, receiver: { id: receiverId } }, // sender -> receiver
-      { sender: { id: receiverId }, receiver: { id: senderId } }, // receiver -> sender
-    ]);
-    if (friendship !== null) {
-      throw new ConflictException(
-        friendship.accept ? '이미 친구인 유저입니다.' : '이미 친구 신청을 보냈거나 받은 유저입니다.',
-      );
-    }
-    await this.checkFriendLimit(senderId, '나');
-    await this.checkFriendLimit(receiverId, '상대방');
-    await this.checkFriendRequestLimit(receiverId);
-
-    await this.friendshipRepository.insert({
-      sender: { id: senderId },
-      receiver: { id: receiverId },
-    });
-    return new SuccessResponseDto('친구 신청을 보냈습니다.');
-  }
-
-  // !SECTION private
 
   // SECTION: public
   /**
@@ -121,8 +39,8 @@ export class FriendService {
         await this.friendshipRepository.find({
           relations: ['sender', 'receiver', 'messageView'],
           where: [
-            { sender: { id: userId }, accept: true },
-            { receiver: { id: userId }, accept: true },
+            { senderId: userId, accept: true },
+            { receiverId: userId, accept: true },
           ],
           order: { lastMessegeTime: 'DESC' },
         })
@@ -166,7 +84,7 @@ export class FriendService {
       requests: (
         await this.friendshipRepository.find({
           relations: ['sender'],
-          where: { receiver: { id: userId }, accept: false },
+          where: { receiverId: userId, accept: false },
         })
       ).map((friendship) => friendship.sender),
     };
@@ -208,7 +126,6 @@ export class FriendService {
     if (senderId === receiverId) {
       throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
     }
-
     const friendship = await this.findExistFriendRequest(senderId, receiverId);
     await this.checkFriendLimit(receiverId, '나');
     await this.checkFriendLimit(senderId, '상대방');
@@ -232,4 +149,88 @@ export class FriendService {
     return new SuccessResponseDto('친구 신청을 거절했습니다.');
   }
   // !SECTION public
+
+  // SECTION: private
+  /**
+   * 친구 정원이 꽉 찼는지 확인한다.
+   *
+   * @param userId 친구 수를 체크할 유저
+   * @param userType 유저의 타입 ( 나 or 상대방 )
+   */
+  private async checkFriendLimit(userId: number, userType: string): Promise<void> {
+    if (
+      (await this.friendshipRepository.countBy([
+        { receiverId: userId, accept: true },
+        { senderId: userId, accept: true },
+      ])) >= FRIEND_LIMIT
+    ) {
+      throw new ForbiddenException(`${userType}의 친구 정원이 꽉 찼습니다.`);
+    }
+  }
+
+  /**
+   * 친구 신청 정원이 꽉 찼는지 확인한다.
+   *
+   * @param userId 친구 신청 수를 체크할 유저
+   */
+  private async checkFriendRequestLimit(userId: number): Promise<void> {
+    if ((await this.friendshipRepository.countBy({ receiver: { id: userId }, accept: false })) >= FRIEND_LIMIT) {
+      throw new ForbiddenException('친구 신청 정원이 꽉 찬 유저입니다.');
+    }
+  }
+
+  /**
+   * sender -> receiver 로 보낸 친구 신청이 있는지 확인하고 반환.
+   *
+   * @param senderId 보낸 사람
+   * @param receiverId 받은 사람
+   * @returns sender 가 receiver 에게 보낸 친구 신청 정보
+   */
+  private async findExistFriendRequest(senderId: number, receiverId: number): Promise<Friendship> {
+    const friendship = await this.friendshipRepository.findOneBy({ senderId, receiverId });
+    if (friendship === null) {
+      throw new NotFoundException('존재하지 않는 친구 신청입니다.');
+    }
+    if (friendship.accept === true) {
+      throw new ConflictException('이미 친구인 유저입니다.');
+    }
+    return friendship;
+  }
+
+  /**
+   * 친구 신청을 보낸다.
+   *
+   * @param senderId 보내는 유저 (나)
+   * @param receiverId 신청 받는 유저 (상대방)
+   * @returns
+   */
+  private async requestFriend(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
+    if (senderId === receiverId) {
+      throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
+    }
+    if ((await this.blockedService.findBlockedUser(senderId, receiverId)) === null) {
+      throw new ForbiddenException('당신을 차단한 유저입니다.');
+    }
+    if ((await this.blockedService.findBlockedUser(receiverId, senderId)) === null) {
+      throw new ForbiddenException('당신이 차단한 유저입니다.');
+    }
+    // 친구 신청 혹은 친구 관계가 있는 지 확인. 하나라도 있으면 error 이므로 findOneBy.
+    const friendship = await this.friendshipRepository.findOneBy([
+      { senderId: senderId, receiverId: receiverId }, // sender -> receiver
+      { senderId: receiverId, receiverId: senderId }, // receiver -> sender
+    ]);
+    if (friendship !== null) {
+      throw new ConflictException(
+        friendship.accept ? '이미 친구인 유저입니다.' : '이미 친구 신청을 보냈거나 받은 유저입니다.',
+      );
+    }
+    await this.checkFriendLimit(senderId, '나');
+    await this.checkFriendLimit(receiverId, '상대방');
+    await this.checkFriendRequestLimit(receiverId);
+
+    await this.friendshipRepository.insert({ senderId, receiverId });
+    return new SuccessResponseDto('친구 신청을 보냈습니다.');
+  }
+
+  // !SECTION private
 }

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -126,11 +126,12 @@ export class FriendService {
           ],
           order: { lastMessegeTime: 'DESC' },
         })
-      ).map(({ sender, receiver, lastMessegeTime, messageView }) => {
+      ).map(({ id, sender, receiver, lastMessegeTime, messageView }) => {
         // messgeView 가 없으면 (find() 가 undefined 이면) null
         const lastViewTime = messageView.find((view) => view.user.id === userId)?.lastViewTime || null;
         return {
-          ...(sender.id === userId ? receiver : sender),
+          friendId: id,
+          user: sender.id === userId ? receiver : sender,
           lastMessegeTime,
           lastViewTime,
         };

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -40,7 +40,7 @@ export class UserService {
     await this.checkAlreadyExistUser(authId);
     await this.checkDuplicatedNickname(nickname);
     await this.userRepository.manager.transaction(async (manager: EntityManager) => {
-      await manager.insert('user', { id: authId, nickname: nickname });
+      await manager.insert('users', { id: authId, nickname: nickname });
       await manager.update('auth', { id: authId }, { status: AuthStatus.REGISTERD });
     });
     return new UserNicknameResponseDto(nickname);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -4,6 +4,7 @@ import { EntityManager, Repository } from 'typeorm';
 
 import { AuthService } from '../auth/auth.service';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { AuthStatus } from '../entity/auth.entity';
 import { User } from '../entity/user.entity';
 
 import { UserInfoResponseDto } from './dto/user-info-response.dto';
@@ -39,8 +40,8 @@ export class UserService {
     await this.checkAlreadyExistUser(authId);
     await this.checkDuplicatedNickname(nickname);
     await this.userRepository.manager.transaction(async (manager: EntityManager) => {
-      await manager.insert(User, { id: authId, nickname: nickname });
-      await this.authService.changeAuthStatus(authId);
+      await manager.insert('user', { id: authId, nickname: nickname });
+      await manager.update('auth', { id: authId }, { status: AuthStatus.REGISTERD });
     });
     return new UserNicknameResponseDto(nickname);
   }


### PR DESCRIPTION
## Summary
- 친구 리스트 get 하는 api 명세 변경
- 친구와 차단 api 에 부족했던 관계 로직 추가.
  - 차단시 친구, 쌍방 친구신청 row 제거
- 친구 신청 전 block 여부 check

## Describe your changes
- 친구 리스트 get 하는 api 에 message id 추가 및 객체 변경
  - api 가 바뀜에 따라 `FriendResponseDto` 도 변경되었습니다.
- transaction 이용하여 친구, 친구 신청을 모두 삭제하는 로직 추가
- friendship entity 변경
  - sender => senderId, sender
  - receiver => receiverId, receiver
- 친구 신청시 차단관계면 불가능하도록 처리
- friend 에서 block 사용 부분을 `BlockedService` -> `BlockedUserrepository` 를 사용하도록 변경
- `FriendService` 메소드 순서를 `private` 이 밑으로 가게 변경
- `AuthService` 에 있던 리팩토링으로 안쓰게 된 `changeAuthStatus` 메소드 제거
- `BlockedService` 의 에러 시 상태코드 일부 변경 (`Conflict` -> `BadRequest`)

## Issue number and link
- close #105 
- close #125 