### PR TITLE
✨ [Feature] Add nickname to id pipe 

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js'],
+  ignorePatterns: ['.eslintrc.js', '*.spec.ts'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -12,6 +12,7 @@ import {
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { NicknameToIdPipe } from '../common/pipe/nickname-to-id.pipe';
 
 import { BlockedService } from './blocked.service';
 import { BlockedUserResponseDto } from './dto/response/blocked-user-response.dto';
@@ -36,9 +37,9 @@ export class BlockedController {
   @Post()
   blockUserByNickname(
     @Headers('x-my-id') myId: number,
-    @Query('nickname') nickname: string,
+    @Query('nickname', NicknameToIdPipe) userId: number,
   ): Promise<SuccessResponseDto> {
-    return this.blockedService.blockUserByNickname(+myId, nickname);
+    return this.blockedService.blockUser(+myId, userId);
   }
 
   @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
@@ -49,7 +50,7 @@ export class BlockedController {
   @HttpCode(HttpStatus.OK)
   @Post(':userId')
   blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
-    return this.blockedService.blockUserById(+myId, +userId);
+    return this.blockedService.blockUser(+myId, userId);
   }
 
   @ApiOperation({ summary: '유저 차단 해제' })

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -25,6 +25,8 @@ export class BlockedService {
   ) {}
 
   async blockUser(myId: number, userId: number): Promise<SuccessResponseDto> {
+    // NOTE: seperate to userId pipe
+    await this.userService.findExistUserById(userId);
     if (myId === userId) {
       throw new BadRequestException('스스로를 미워하지 마십시오.');
     }
@@ -34,16 +36,6 @@ export class BlockedService {
     await this.checkBlockedCountLimit(myId);
     await this.blockUserAndDeleteFriendships(myId, userId);
     return { message: '유저를 차단하였습니다.' };
-  }
-
-  async blockUserById(myId: number, userId: number): Promise<SuccessResponseDto> {
-    await this.userService.findExistUserById(userId);
-    return this.blockUser(myId, userId);
-  }
-
-  async blockUserByNickname(myId: number, nickname: string): Promise<SuccessResponseDto> {
-    const user = await this.userService.findExistUserByNickname(nickname);
-    return this.blockUser(myId, user.id);
   }
 
   async deleteBlockedUser(myId: number, userId: number): Promise<SuccessResponseDto> {

--- a/backend/src/common/dto/success-response.dto.ts
+++ b/backend/src/common/dto/success-response.dto.ts
@@ -1,9 +1,6 @@
 import { SuccessResponse } from '@/types/common/response';
 
 export class SuccessResponseDto implements SuccessResponse {
-  constructor(message: string) {
-    this.message = message;
-  }
   /**
    * 성공 응답 메세지
    * @example '요청이 처리되었습니다.'

--- a/backend/src/common/pipe/nickname-to-id.pipe.spec.ts
+++ b/backend/src/common/pipe/nickname-to-id.pipe.spec.ts
@@ -1,0 +1,65 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { UserService } from '../../user/user.service';
+import { NicknameToIdPipe } from './nickname-to-id.pipe';
+
+describe('NicknameToUserIdPipe', () => {
+  let pipe: NicknameToIdPipe;
+  let userService: UserService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        NicknameToIdPipe,
+        {
+          provide: UserService,
+          useValue: {
+            findExistUserByNickname: jest.fn().mockResolvedValue({ id: 1234 } as any),
+          },
+        },
+      ],
+    }).compile();
+
+    pipe = moduleRef.get<NicknameToIdPipe>(NicknameToIdPipe);
+    userService = moduleRef.get<UserService>(UserService);
+  });
+
+  describe('transform', () => {
+    const nickname = 'testuser';
+
+    // NOTE: Success case
+    it('nickname 으로 userId 를 찾아서 반환', async () => {
+      const userId = 1234;
+      jest.spyOn(userService, 'findExistUserByNickname').mockResolvedValue({ id: userId } as any);
+
+      const result = await pipe.transform(nickname);
+
+      expect(result).toEqual(userId);
+      expect(userService.findExistUserByNickname).toHaveBeenCalledWith(nickname);
+    });
+
+    // NOTE: Failure case
+    it('nickname 이 빈 문자열일 경우 BadRequestException', async () => {
+      expect(pipe.transform('')).rejects.toThrow();
+    });
+
+    it('nickname 이 undefined 일 경우 BadRequestException', async () => {
+      expect(pipe.transform(undefined as unknown as string)).rejects.toThrow();
+    });
+
+    it('nickname 이 8자 초과일 경우 BadRequestException', async () => {
+      expect(pipe.transform('123456789')).rejects.toThrow(BadRequestException);
+    });
+
+    it('nickname 에 허용되지 않은 문자가 들어갔을 경우 BadRequestException', async () => {
+      expect(pipe.transform('testuser!')).rejects.toThrow(BadRequestException);
+    });
+
+    it('nickname 과 일치하는 유저가 없을 경우 NotFoundException', async () => {
+      jest.spyOn(userService, 'findExistUserByNickname').mockRejectedValueOnce(new NotFoundException());
+
+      await expect(pipe.transform(nickname)).rejects.toThrow();
+      expect(userService.findExistUserByNickname).toHaveBeenCalledWith(nickname);
+    });
+  });
+});

--- a/backend/src/common/pipe/nickname-to-id.pipe.ts
+++ b/backend/src/common/pipe/nickname-to-id.pipe.ts
@@ -1,0 +1,19 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { matches } from 'class-validator';
+
+import { UserService } from '../../user/user.service';
+
+@Injectable()
+export class NicknameToIdPipe implements PipeTransform<string, Promise<number>> {
+  constructor(private readonly userService: UserService) {}
+  async transform(nickname: string) {
+    // validate
+    if (!matches(nickname, /^[가-힣a-zA-Z0-9]{1,8}$/)) {
+      throw new BadRequestException('닉네임이 유효하지 않습니다.');
+    }
+
+    // transform
+    const user = await this.userService.findExistUserByNickname(nickname);
+    return user.id;
+  }
+}

--- a/backend/src/common/pipe/nickname-to-id.pipe.ts
+++ b/backend/src/common/pipe/nickname-to-id.pipe.ts
@@ -9,7 +9,7 @@ export class NicknameToIdPipe implements PipeTransform<string, Promise<number>> 
   async transform(nickname: string) {
     // validate
     if (!matches(nickname, /^[가-힣a-zA-Z0-9]{1,8}$/)) {
-      throw new BadRequestException('닉네임이 유효하지 않습니다.');
+      throw new BadRequestException('유효하지 않은 닉네임 입니다.');
     }
 
     // transform

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -12,6 +12,7 @@ import {
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { NicknameToIdPipe } from '../common/pipe/nickname-to-id.pipe';
 
 import { FriendsResponseDto } from './dto/response/friend-response.dto';
 import { RequestedFriendsResponseDto } from './dto/response/requested-friend-response.dto';
@@ -29,7 +30,6 @@ export class FriendController {
     return this.friendService.getFriendsList(+myId);
   }
 
-  // TODO : validtaion pipe 추가..
   @ApiOperation({ summary: '친구 신청하기 (닉네임)' })
   @ApiForbiddenResponse({ type: ErrorResponseDto, description: '친구 신청 정원 초과, 친구 정원 초과' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
@@ -39,10 +39,10 @@ export class FriendController {
   @HttpCode(HttpStatus.OK)
   @Post()
   requestFriendByNickname(
-    @Query('nickname') nickname: string,
+    @Query('nickname', NicknameToIdPipe) userId: number,
     @Headers('x-my-id') myId: number,
   ): Promise<SuccessResponseDto> {
-    return this.friendService.requestFriendByNickname(+myId, nickname);
+    return this.friendService.requestFriend(+myId, userId);
   }
 
   @ApiOperation({ summary: '친구 신청받은 리스트 가져오기' })
@@ -60,7 +60,7 @@ export class FriendController {
   @HttpCode(HttpStatus.OK)
   @Post(':userId')
   requestFriendById(@Param('userId') userId: number, @Headers('x-my-id') myId: number): Promise<SuccessResponseDto> {
-    return this.friendService.requestFriendById(+myId, userId);
+    return this.friendService.requestFriend(+myId, userId);
   }
 
   @ApiOperation({ summary: '친구 삭제하기' })

--- a/backend/src/user/dto/request/user-nickname-request.dto.ts
+++ b/backend/src/user/dto/request/user-nickname-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, Matches, MaxLength } from 'class-validator';
+import { Matches } from 'class-validator';
 
 import { UserNicknameRequest } from '@/types/user/request';
 
@@ -7,9 +7,6 @@ export class UserNicknameRequestDto implements UserNicknameRequest {
    * nickname
    * @example 'san1'
    */
-  @IsNotEmpty()
-  @IsString()
-  @MaxLength(8)
-  @Matches(/^[가-힣a-zA-Z0-9]*$/)
+  @Matches(/^[가-힣a-zA-Z0-9]{1,8}$/, { message: '유효하지 않은 닉네임 입니다.' })
   nickname: string;
 }


### PR DESCRIPTION
## Summary
- nickname 을 user id 로 바꾸는 `NicknameToIdPipe` 구현
## Describe your changes
- 유저 차단, 친구 신청 시 받는 query string 의 `nickname` 을 검증하는 pipe 를 구현했습니다. 정규식과 `class-validator` 의 `match()` 를 사용해서 검사합니다. `false` 일 경우 `BadRequestException` 을 throw 합니다.
- pipe 를 test 하는 spec 파일을 생성했습니다.
  - 테스트 결과
    <img width="666" alt="Screenshot 2023-05-01 at 3 21 05 PM" src="https://user-images.githubusercontent.com/71019735/235416087-d6b89153-e357-4b10-83c0-526fde8528ac.png">
  - 테스트 파일에서 `as any` 를 자주 사용하는데 `eslint` 로 검사할 필요가 없다고 판단해서`*.spec.ts` 파일은 무시하도록 했습니다. 
- 기존 로직을 pipe 를 사용하는 방향으로 변경하고 공통되는 함수를 합쳐서 리팩토링 했습니다.
- 현재 nickname + userId 로직이 합쳐지면서 닉네임을 사용하는 api 에서는 유효한 user 인지 검사를 두 번 하게 되는데 추후 `userId` 만 검증하는 pipe 로 분리하기 위해 `NOTE` anchor 로 표시해놨으니 참고바랍니다.

## Issue number and link
- close #161 