### PR TITLE
✨ [Feature] Add check user id pipe

### DIFF
--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Delete, Get, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -12,6 +23,7 @@ import {
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { CheckUserIdPipe } from '../common/pipe/check-user-id.pipe';
 import { NicknameToIdPipe } from '../common/pipe/nickname-to-id.pipe';
 
 import { BlockedService } from './blocked.service';
@@ -32,7 +44,7 @@ export class BlockedController {
   @ApiForbiddenResponse({ type: ErrorResponseDto, description: '차단 목록 정원 다참' })
   @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 차단한 유저' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  @ApiQuery({ name: 'nickname', description: '차단할 유저 닉네임' })
+  @ApiQuery({ type: String, name: 'nickname', description: '차단할 유저 닉네임' })
   @HttpCode(HttpStatus.OK)
   @Post()
   blockUserByNickname(
@@ -49,7 +61,10 @@ export class BlockedController {
   @ApiParam({ name: 'userId', description: '차단할 사람 아이디' })
   @HttpCode(HttpStatus.OK)
   @Post(':userId')
-  blockUserById(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
+  blockUserById(
+    @Headers('x-my-id') myId: number,
+    @Param('userId', ParseIntPipe, CheckUserIdPipe) userId: number,
+  ): Promise<SuccessResponseDto> {
     return this.blockedService.blockUser(+myId, userId);
   }
 
@@ -58,7 +73,10 @@ export class BlockedController {
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @ApiParam({ name: 'userId', description: '차단 해제할 사람 아이디' })
   @Delete(':userId')
-  deleteBlockedUser(@Headers('x-my-id') myId: number, @Param('userId') userId: number): Promise<SuccessResponseDto> {
+  deleteBlockedUser(
+    @Headers('x-my-id') myId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+  ): Promise<SuccessResponseDto> {
     return this.blockedService.deleteBlockedUser(+myId, userId);
   }
 }

--- a/backend/src/blocked/blocked.module.ts
+++ b/backend/src/blocked/blocked.module.ts
@@ -2,13 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BlockedUser } from '../entity/blocked-user.entity';
-import { UserModule } from '../user/user.module';
+import { User } from '../entity/user.entity';
 
 import { BlockedController } from './blocked.controller';
 import { BlockedService } from './blocked.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlockedUser]), UserModule],
+  imports: [TypeOrmModule.forFeature([BlockedUser, User])],
   controllers: [BlockedController],
   providers: [BlockedService],
   exports: [BlockedService],

--- a/backend/src/blocked/blocked.service.ts
+++ b/backend/src/blocked/blocked.service.ts
@@ -12,7 +12,6 @@ import { BLOCKED_USER_LIMIT } from '../common/constant';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { BlockedUser } from '../entity/blocked-user.entity';
 import { Friendship } from '../entity/friendship.entity';
-import { UserService } from '../user/user.service';
 
 import { BlockedUserResponseDto } from './dto/response/blocked-user-response.dto';
 
@@ -21,12 +20,9 @@ export class BlockedService {
   constructor(
     @InjectRepository(BlockedUser)
     private readonly blockedUserRepository: Repository<BlockedUser>,
-    private readonly userService: UserService,
   ) {}
 
   async blockUser(myId: number, userId: number): Promise<SuccessResponseDto> {
-    // NOTE: seperate to userId pipe
-    await this.userService.findExistUserById(userId);
     if (myId === userId) {
       throw new BadRequestException('스스로를 미워하지 마십시오.');
     }
@@ -64,7 +60,7 @@ export class BlockedService {
    * @param userId 나의 id
    * @param blockedUserId 차단당할 유저의 id
    */
-  async findBlockedUser(userId: number, blockedUserId: number): Promise<BlockedUser | null> {
+  private async findBlockedUser(userId: number, blockedUserId: number): Promise<BlockedUser | null> {
     return this.blockedUserRepository.findOneBy({ userId: userId, blockedUserId: blockedUserId });
   }
 

--- a/backend/src/common/pipe/check-user-id.pipe.spec.ts
+++ b/backend/src/common/pipe/check-user-id.pipe.spec.ts
@@ -1,0 +1,7 @@
+import { CheckUserIdPipe } from './check-user-id.pipe';
+
+describe.skip('CheckUserIdPipe', () => {
+  it('should be defined', () => {
+    //expect(new CheckUserIdPipe()).toBeDefined();
+  });
+});

--- a/backend/src/common/pipe/check-user-id.pipe.ts
+++ b/backend/src/common/pipe/check-user-id.pipe.ts
@@ -1,0 +1,17 @@
+import { Injectable, NotFoundException, PipeTransform } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { User } from '../../entity/user.entity';
+
+@Injectable()
+export class CheckUserIdPipe implements PipeTransform<number, Promise<number>> {
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
+  async transform(userId: number): Promise<number> {
+    const user = await this.userRepository.findOneBy({ id: userId });
+    if (user === null) {
+      throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
+    return userId;
+  }
+}

--- a/backend/src/common/pipe/nickname-to-id.pipe.ts
+++ b/backend/src/common/pipe/nickname-to-id.pipe.ts
@@ -1,11 +1,13 @@
-import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException, PipeTransform } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import { matches } from 'class-validator';
+import { Repository } from 'typeorm';
 
-import { UserService } from '../../user/user.service';
+import { User } from '../../entity/user.entity';
 
 @Injectable()
 export class NicknameToIdPipe implements PipeTransform<string, Promise<number>> {
-  constructor(private readonly userService: UserService) {}
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
   async transform(nickname: string) {
     // validate
     if (!matches(nickname, /^[가-힣a-zA-Z0-9]{1,8}$/)) {
@@ -13,7 +15,10 @@ export class NicknameToIdPipe implements PipeTransform<string, Promise<number>> 
     }
 
     // transform
-    const user = await this.userService.findExistUserByNickname(nickname);
+    const user = await this.userRepository.findOneBy({ nickname });
+    if (user === null) {
+      throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
     return user.id;
   }
 }

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Delete, Get, Headers, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -12,6 +23,7 @@ import {
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { CheckUserIdPipe } from '../common/pipe/check-user-id.pipe';
 import { NicknameToIdPipe } from '../common/pipe/nickname-to-id.pipe';
 
 import { FriendsResponseDto } from './dto/response/friend-response.dto';
@@ -35,7 +47,7 @@ export class FriendController {
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
   @ApiConflictResponse({ type: ErrorResponseDto, description: '이미 친구 상태, 이미 친구 신청 상태' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  @ApiQuery({ name: 'nickname', description: '친구 신청할 유저의 닉네임' })
+  @ApiQuery({ type: String, name: 'nickname', description: '친구 신청할 유저의 닉네임' })
   @HttpCode(HttpStatus.OK)
   @Post()
   requestFriendByNickname(
@@ -59,13 +71,19 @@ export class FriendController {
   @ApiParam({ name: 'userId', description: '친구 신청할 유저의 아이디' })
   @HttpCode(HttpStatus.OK)
   @Post(':userId')
-  requestFriendById(@Param('userId') userId: number, @Headers('x-my-id') myId: number): Promise<SuccessResponseDto> {
+  requestFriendById(
+    @Param('userId', ParseIntPipe, CheckUserIdPipe) userId: number,
+    @Headers('x-my-id') myId: number,
+  ): Promise<SuccessResponseDto> {
     return this.friendService.requestFriend(+myId, userId);
   }
 
   @ApiOperation({ summary: '친구 삭제하기' })
   @Delete(':userId')
-  deleteFriend(@Param('userId') userId: number, @Headers('x-my-id') myId: number): Promise<SuccessResponseDto> {
+  deleteFriend(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Headers('x-my-id') myId: number,
+  ): Promise<SuccessResponseDto> {
     return this.friendService.deleteFriend(+myId, userId);
   }
 
@@ -75,7 +93,10 @@ export class FriendController {
   @ApiParam({ name: 'userId', description: '친구 신청 수락할 유저의 아이디' })
   @HttpCode(HttpStatus.OK)
   @Post('accept/:userId')
-  acceptFriendRequest(@Param('userId') userId: number, @Headers('x-my-id') myId: number): Promise<SuccessResponseDto> {
+  acceptFriendRequest(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Headers('x-my-id') myId: number,
+  ): Promise<SuccessResponseDto> {
     return this.friendService.acceptFriendRequest(userId, +myId);
   }
 
@@ -83,7 +104,10 @@ export class FriendController {
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @HttpCode(HttpStatus.OK)
   @Post('reject/:userId')
-  rejectFriendRequest(@Param('userId') userId: number, @Headers('x-my-id') myId: number): Promise<SuccessResponseDto> {
+  rejectFriendRequest(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Headers('x-my-id') myId: number,
+  ): Promise<SuccessResponseDto> {
     // FIXME: myId 임시 헤더라서 + 갈겼습니다...
     return this.friendService.rejectFriendRequest(userId, +myId);
   }

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -4,13 +4,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { BlockedUser } from '../entity/blocked-user.entity';
 import { Friendship } from '../entity/friendship.entity';
 import { MessageView } from '../entity/message-view.entity';
-import { UserModule } from '../user/user.module';
+import { User } from '../entity/user.entity';
 
 import { FriendController } from './friend.controller';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, BlockedUser, MessageView]), UserModule],
+  imports: [TypeOrmModule.forFeature([Friendship, BlockedUser, MessageView, User])],
   controllers: [FriendController],
   providers: [FriendService],
 })

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -12,7 +12,6 @@ import { FRIEND_LIMIT } from '../common/constant';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { BlockedUser } from '../entity/blocked-user.entity';
 import { Friendship } from '../entity/friendship.entity';
-import { UserService } from '../user/user.service';
 
 import { FriendsResponseDto } from './dto/response/friend-response.dto';
 import { RequestedFriendsResponseDto } from './dto/response/requested-friend-response.dto';
@@ -24,7 +23,6 @@ export class FriendService {
     private readonly friendshipRepository: Repository<Friendship>,
     @InjectRepository(BlockedUser)
     private readonly blockedUserRepository: Repository<BlockedUser>,
-    private readonly userService: UserService,
   ) {}
 
   // SECTION: public
@@ -66,8 +64,6 @@ export class FriendService {
    * @returns
    */
   async requestFriend(senderId: number, receiverId: number): Promise<SuccessResponseDto> {
-    // NOTE: seperate to userId pipe
-    await this.userService.findExistUserById(receiverId);
     if (senderId === receiverId) {
       throw new BadRequestException('당신은 이미 당신의 소중한 친구입니다. ^_^');
     }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,21 +1,22 @@
-import { ValidationPipe } from '@nestjs/common';
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
+import { ValidationError } from 'class-validator';
 
 import { AppModule } from './app.module';
 import { AppConfigService } from './config/app/configuration.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  // validation pipe 를 global 으로 사용.
-  // (transform: true 는 DTO 에서 @IsNumber() 를 사용할 때, string 을 number 로 자동 변환해줌)
   app.useGlobalPipes(
     new ValidationPipe({
-      transform: true,
       whitelist: true,
       forbidNonWhitelisted: true,
       // validateCustomDecorators: true, // custom decorator 에 대한 validation 을 수행
+      exceptionFactory: (validationErrors: ValidationError[] = []) => {
+        return new BadRequestException(Object.values(validationErrors[0]?.constraints || {})[0]);
+      },
     }),
   );
   app.use(cookieParser());

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, Headers } from '@nestjs/common';
+import { Controller, Get, Param, Query, Headers, ParseIntPipe } from '@nestjs/common';
 import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
@@ -18,8 +18,8 @@ export class MessageController {
   @ApiQuery({ name: 'offset', required: false, description: '마지막으로 가져온 메시지의 id' })
   @Get(':friendId')
   getMessagesList(
-    @Param('friendId') friendId: number,
-    @Query('offset') offset: number,
+    @Param('friendId', ParseIntPipe) friendId: number,
+    @Query('offset', ParseIntPipe) offset: number,
     @Headers('x-my-id') myId: number,
   ): Promise<MessageResponseDto> {
     return this.messageService.getMessagesList(+myId, friendId, offset);

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -30,6 +31,7 @@ import { Response } from 'express';
 
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
+import { CheckUserIdPipe } from '../common/pipe/check-user-id.pipe';
 
 import { UserImageRequestDto } from './dto/request/user-image-request.dto';
 import { UserNicknameRequestDto } from './dto/request/user-nickname-request.dto';
@@ -112,7 +114,7 @@ export class UserController {
   @ApiOperation({ summary: '유저 프로필 가져오기' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '존재하지 않는 사용자' })
   @Get(':userId/profile')
-  getUserProfile(@Param('userId') userId: number): Promise<UserProfileResponseDto> {
+  getUserProfile(@Param('userId', ParseIntPipe) userId: number): Promise<UserProfileResponseDto> {
     return this.userService.getUserProfile(userId);
   }
 
@@ -121,7 +123,10 @@ export class UserController {
   @ApiQuery({ name: 'cursor', description: '페이지 번호', required: false, example: 1 })
   @ApiParam({ name: 'userId', description: '유저 아이디', example: 1 })
   @Get(':userId/history')
-  getUserHistory(@Param('userId') userId: number, @Query('cursor') cursor: number): Promise<UserHistoryResponseDto> {
+  getUserHistory(
+    @Param('userId', ParseIntPipe, CheckUserIdPipe) userId: number,
+    @Query('cursor', ParseIntPipe) cursor: number,
+  ): Promise<UserHistoryResponseDto> {
     return this.userService.getUserHistory(userId, cursor);
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -55,7 +55,6 @@ export class UserService {
   }
 
   async updateUserImage(myId: number, imageUrl: string): Promise<SuccessResponseDto> {
-    await this.findExistUserById(myId);
     await this.userRepository.update({ id: myId }, { image: imageUrl });
     return { message: '이미지 변경 완료되었습니다.' };
   }
@@ -79,7 +78,6 @@ export class UserService {
   }
 
   async getUserHistory(userId: number, cursor: number): Promise<UserHistoryResponseDto> {
-    await this.findExistUserById(userId);
     const histories = await this.gameHistoryRepository.find({
       relations: ['winner', 'loser'],
       where: [{ winner: { id: userId } }, { loser: { id: userId } }],
@@ -93,22 +91,6 @@ export class UserService {
   /*
   validation method
   */
-
-  async findExistUserById(userId: number): Promise<User> {
-    const user = await this.userRepository.findOneBy({ id: userId });
-    if (user === null) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
-    }
-    return user;
-  }
-
-  async findExistUserByNickname(nickname: string): Promise<User> {
-    const user = await this.userRepository.findOneBy({ nickname: nickname });
-    if (user === null) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
-    }
-    return user;
-  }
 
   private async checkDuplicatedNickname(nickname: string): Promise<void> {
     if (await this.userRepository.findOneBy({ nickname })) {
@@ -148,8 +130,4 @@ export class UserService {
     }
     return user;
   }
-
-  /*
-  repository method
-  */
 }


### PR DESCRIPTION
## Summary
- 해당하는 유저가 없으면 404 에러를 보내는 `CheckUserIdPipe` 구현
- 내장 `ValidtaionPipe` 에서 보내던 error message 형태를 `string` 으로 변경
- `ValidationPipe` 의 `transform: true` 삭제
## Describe your changes
### 1. `CheckUserPipe` 생성
- `NicknameToIdPipe` 에서 `UserService` 를 사용하던 부분을 `Repository<User>` 로 변경
- user 가 없으면 404 에러를 보내는 `CheckUserIdPipe` 구현
  - 기존 `findExistUserById` 를 사용하던 부분에 `CheckUserIdPipe` 를 적용했습니다.
- pipe 로 분리된 메소드를 `UserService` 에서 삭제
  - `findExistUserById`, `findExistUserByNickname` 을 삭제했습니다.
  - pipe 에서 service 를 사용하는 방법도 있었는데, controller 이전에 처리될 것이기 때문에 더 안쪽에 있는 service layer 를 사용하는 것은 적절치 않다고 판단했습니다.
- 사용되지 않는 `UserModule`, `UserService` import 삭제
  - 기존 다른 service 에서 참조되는 관계를 삭제하면서 import 문들도 삭제되었습니다.
### 2. `ValidationPipe` 변경
- `NicknameToIdPipe` 테스트 결과 전역으로 적용된 `ValidtaionPipe({transform: true})` 에 의해 `nickname` 이 해당 파이프에 들어오기 전에 먼저 `number` 로 변환되어 버려서 `transform: true` 옵션을 삭제했습니다.
  - 기존 `transform: true` 가 해주던 `string` -> `number` 변환을 유지하기 위해 `ParseIntPipe` 을 적용했습니다. 
- 에러 메세지로 를 `string` 으로 만들어서 `BadRequest` 를 `throw` 하는 `exceptionFactory` 설정
  - 설정한 `exceptionFactory` 함수는 `class-validator` 의 `validate()` 가 실패되었을 경우 실행됩니다.
  - #170 에러를 해결하기 위해 일어난 에러의 배열인 `ValidationError[]` 중 첫 번째 element 를 꺼내서 에러 메세지 (`constraint`) 를 직접 적용합니다.
  - `ValidationError` 는 이렇게 생겼습니다.
    ```ts
    ValidationError {
      target: UserNicknameRequestDto { nickname: 'sa2314324123412n1' },
      value: 'sa2314324123412n1',
      property: 'nickname',
      children: [],
      constraints: { matches: '유효하지 않은 닉네임 입니다.' }
    }
    ```
  - `constraints` 의 key 가 예시에서는 `matches` 인데, 어떤 decorator 에서 검증되었냐에 따라 다른 key 값이 오므로 일정한 값으로 뽑을 수가 없어서 `Object.values` 로 배열로 만든 후 [0] 값 을 추출했습니다.
## Issue number and link
- close #163 
- close #170 