### PR TITLE
🐛 [Fix] Grid component's grid-template-rows

### DIFF
--- a/frontend/src/layout/Grid/Grid.tsx
+++ b/frontend/src/layout/Grid/Grid.tsx
@@ -114,7 +114,7 @@ const StyledGridContainer = styled(StyledGrid)<GridProps<'grid'>>`
     };`}
     ${props.rows &&
     `grid-template-rows: ${
-      props.rowsSize ? `${props.rowsSize.map((size) => size + 'fr').join(' ')}` : `repeat(${props.columns}, 1fr)`
+      props.rowsSize ? `${props.rowsSize.map((size) => size + 'fr').join(' ')}` : `repeat(${props.rows}, 1fr)`
     };`}
     ${props.areas && `grid-template-areas: ${props.areas};`}
     ${props.autoColumns && `grid-auto-columns: ${props.autoColumns};`}


### PR DESCRIPTION
## Summary
grid component에서 row와 column을 지정해주어도 colxcol기준으로 grid가 만들어지는 error를 고쳤습니다.
## Describe your changes

## Issue number and link

- [x] https://github.com/GhostPangPang/GhostPong/issues/178