### PR TITLE
🐛 [BugFix] Set server enbaleCors

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,28 +1,34 @@
 # node server
 NODE_ENV=development
 
-APP_PORT=
-APP_URL=
+APP_PORT=3000
+APP_URL=http://localhost
 
-# Postgres database
+# client application url
+CLIENT_URL=
+
+# Postgres database - docker env 로 사용
+# database name
 DB_NAME=
+# database port (default: 5432)
 DB_PORT=
+# database user (username 은 실행중인 호스트 머신과 달라도 됩니다.)
 DB_USER=
+# database password
 DB_PASSWORD=
-DB_HOST=
+DB_HOST=localhost
 
 # db name for test
-TEST_DB_NAME=
+TEST_DB_NAME=localhost
 
 # 42인트라넷에서 발급받은 API ID
 FORTYTWO_APP_ID=
 # 42인트라넷에서 발급받은 API SECRET KEY
 FORTYTWO_APP_SECRET=
 # 42인트라넷에서 입력한 callback url
-CALLBACK_URL=
+CALLBACK_URL=${APP_URL}:${APP_PORT}/auth/42login/callback
 
 # JWT token secret 값
 USER_JWT_SECRETKEY=
-
 # JWT token secret 값
 AUTH_JWT_SECRETKEY=

--- a/backend/src/config/app/configuration.module.ts
+++ b/backend/src/config/app/configuration.module.ts
@@ -13,6 +13,7 @@ import { AppConfigService } from './configuration.service';
         APP_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
         APP_URL: Joi.string().default('localhost'),
         APP_PORT: Joi.number().default(3000),
+        CLIENT_URL: Joi.string().default('http://localhost:5173'),
       }),
     }),
   ],

--- a/backend/src/config/app/configuration.service.ts
+++ b/backend/src/config/app/configuration.service.ts
@@ -16,4 +16,8 @@ export class AppConfigService {
   get port() {
     return Number(this.configService.get<number>('app.port'));
   }
+
+  get clientUrl() {
+    return this.configService.get<string>('app.clientUrl');
+  }
 }

--- a/backend/src/config/app/configuration.ts
+++ b/backend/src/config/app/configuration.ts
@@ -4,4 +4,5 @@ export default registerAs('app', () => ({
   env: process.env.NODE_ENV,
   url: process.env.APP_URL,
   port: process.env.APP_PORT,
+  clientUrl: process.env.CLIENT_URL,
 }));

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -31,6 +31,12 @@ async function bootstrap() {
   SwaggerModule.setup('api', app, document);
 
   const appConfig: AppConfigService = app.get(AppConfigService);
+  app.enableCors({
+    origin: appConfig.clientUrl,
+    credentials: true,
+    allowedHeaders: ['Authorization', 'x-my-id'],
+    exposedHeaders: ['Location'],
+  });
   await app.listen(appConfig.port);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- client app 에 cors 허용해주는 미들웨어 설정
## Describe your changes
- `backend/env.example` 에 `CLIENT_APP` 이 추가되었습니다. `.env` 작성하실 때 client app 의 host 를 작성해주시면 됩니다.
-  nest app 의 `enableCors()` 로 `express` 의 [`cors`](https://github.com/expressjs/cors#configuring-cors-asynchronously) 패키지를 사용해서 설정할 수 있습니다. `app` 에서 `enableCors()` 해주면 모든 요청에 적용됩니다.
### 속성 설명
- `origin`: `Access-Control-Allow-Origin` 헤더를 설정합니다. env 의 `CLIENT_APP` 이 값으로 들어갑니다.
- `credentials` : `Access-Control-Allow-Credentials` 헤더를 설정합니다. 쿠키와 `Authorization` 헤더 사용을 위해 필요합니다.
- `allowedHeaders`: `Access-Control-Allow-Headers` 헤더를 설정합니다.  다른 origin 에서 온 `request` 헤더 중 허용할 헤더를 설정합니다. `Authorization` 과 `x-my-id` 가 사용되므로 설정했습니다.
- `exposedHeaders`: `Access-Control-Expose-Headers` 헤더를 설정합니다. `Location` 을 응답으로 줄 때가 있으므로 설정했습니다.

mdn 에 각 헤더별 설명이 잘 되어있으니 읽어 보시는 것을 강력 추천합니다!!

설정 후 서버가 보내는 pre-flight 응답 헤더의 값
<img width="425" alt="Screenshot 2023-05-04 at 3 11 47 PM" src="https://user-images.githubusercontent.com/71019735/236124742-888e9284-0271-46a2-8091-140796910082.png">


## Issue number and link
- close #176 