### PR TITLE
:sparkles: [Feature] Add fixed seeding data

### DIFF
--- a/backend/seeding/factory/frieindship.factory.ts
+++ b/backend/seeding/factory/frieindship.factory.ts
@@ -4,12 +4,11 @@ import { faker } from '@faker-js/faker';
 
 import { User } from '../../src/entity/user.entity';
 
-export default (user1: User, user2: User) => {
-  const accept = faker.datatype.boolean();
+export default (user1: User, user2: User, accept: boolean, lastMessegeTime?: Date) => {
   return {
     sender: user1,
     receiver: user2,
     accept,
-    lastMessegeTime: accept && faker.datatype.boolean() ? faker.date.past() : undefined,
+    lastMessegeTime: lastMessegeTime || (accept && faker.datatype.boolean()) ? faker.date.past() : undefined,
   };
 };

--- a/backend/seeding/factory/frieindship.factory.ts
+++ b/backend/seeding/factory/frieindship.factory.ts
@@ -4,11 +4,11 @@ import { faker } from '@faker-js/faker';
 
 import { User } from '../../src/entity/user.entity';
 
-export default (user1: User, user2: User, accept: boolean, lastMessegeTime?: Date) => {
+export default (user1: User, user2: User, accept: boolean, lastMessageTime?: Date) => {
   return {
     sender: user1,
     receiver: user2,
     accept,
-    lastMessegeTime: lastMessegeTime || (accept && faker.datatype.boolean()) ? faker.date.past() : undefined,
+    lastMessageTime: lastMessageTime || (accept && faker.datatype.boolean()) ? faker.date.past() : undefined,
   };
 };

--- a/backend/seeding/factory/message.factory.ts
+++ b/backend/seeding/factory/message.factory.ts
@@ -10,6 +10,6 @@ export default (friendship: Friendship, prevDate?: Date) => {
     senderId: faker.datatype.boolean() ? friendship.sender.id : friendship.receiver.id,
     friendId: friendship.id,
     content: faker.lorem.sentence(),
-    createdAt: prevDate || faker.date.past(2, friendship.lastMessegeTime),
+    createdAt: prevDate || faker.date.past(2, friendship.lastMessageTime),
   };
 };

--- a/backend/seeding/factory/message.factory.ts
+++ b/backend/seeding/factory/message.factory.ts
@@ -4,11 +4,12 @@ import { faker } from '@faker-js/faker';
 
 import { Friendship } from '../../src/entity/friendship.entity';
 
-export default (friendship: Friendship) => {
+export default (friendship: Friendship, prevDate?: Date) => {
+  prevDate?.setDate(prevDate?.getDate() + faker.datatype.number({ min: 1, max: 10 }));
   return {
     senderId: faker.datatype.boolean() ? friendship.sender.id : friendship.receiver.id,
     friendId: friendship.id,
     content: faker.lorem.sentence(),
-    createdAt: faker.date.past(1, friendship.lastMessegeTime),
+    createdAt: prevDate || faker.date.past(2, friendship.lastMessegeTime),
   };
 };

--- a/backend/seeding/seeder/message.seeder.ts
+++ b/backend/seeding/seeder/message.seeder.ts
@@ -87,7 +87,7 @@ export default async (dataSource: DataSource) => {
 
   const messageSeed: Partial<Message>[] = [];
   friends
-    .filter((friend) => friend.lastMessegeTime !== undefined && friend.accept === true)
+    .filter((friend) => friend.lastMessageTime !== undefined && friend.accept === true)
     .map((friend) => {
       const random = Math.floor(Math.random() * 200);
       let prevDate: Date | undefined = undefined;

--- a/backend/src/entity/friendship.entity.ts
+++ b/backend/src/entity/friendship.entity.ts
@@ -29,7 +29,7 @@ export class Friendship {
   @Column({
     default: () => "'-infinity'",
   })
-  lastMessegeTime: Date;
+  lastMessageTime: Date;
 
   @OneToMany(() => MessageView, (messageView) => messageView.friend)
   messageView: MessageView[];

--- a/backend/src/friend/dto/response/friend-response.dto.ts
+++ b/backend/src/friend/dto/response/friend-response.dto.ts
@@ -13,7 +13,7 @@ class FriendInformation {
    * 마지막으로 메세지를 주고 받은 시간
    * @example '2021-08-01T00:00:00.000Z'
    */
-  lastMessegeTime: Date | string | null;
+  lastMessageTime: Date | string | null;
 
   /**
    * 마지막으로 메세지를 읽은 시간 (나)

--- a/backend/src/friend/dto/response/friend-response.dto.ts
+++ b/backend/src/friend/dto/response/friend-response.dto.ts
@@ -13,13 +13,13 @@ class FriendInformation {
    * 마지막으로 메세지를 주고 받은 시간
    * @example '2021-08-01T00:00:00.000Z'
    */
-  lastMessegeTime: Date | null;
+  lastMessegeTime: Date | string | null;
 
   /**
    * 마지막으로 메세지를 읽은 시간 (나)
    * @example '2021-08-01T00:00:00.000Z'
    */
-  lastViewTime: Date | null;
+  lastViewTime: Date | string | null;
 
   /**
    * 친구의 유저 정보

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -41,15 +41,15 @@ export class FriendService {
             { senderId: userId, accept: true },
             { receiverId: userId, accept: true },
           ],
-          order: { lastMessegeTime: 'DESC' },
+          order: { lastMessageTime: 'DESC' },
         })
-      ).map(({ id, sender, receiver, lastMessegeTime, messageView }) => {
+      ).map(({ id, sender, receiver, lastMessageTime, messageView }) => {
         // messgeView 가 없으면 (find() 가 undefined 이면) null
         const lastViewTime = messageView.find((view) => view.user.id === userId)?.lastViewTime || null;
         return {
           id,
           user: sender.id === userId ? receiver : sender,
-          lastMessegeTime,
+          lastMessageTime,
           lastViewTime,
         };
       }),

--- a/backend/src/message/dto/response/message-response.dto.ts
+++ b/backend/src/message/dto/response/message-response.dto.ts
@@ -23,7 +23,7 @@ class MessageInfo {
    * 메세지 보낸 시간
    * @example '2021-08-01T00:00:00.000Z'
    */
-  createdAt: Date;
+  createdAt: Date | string;
 }
 
 export class MessageResponseDto implements MessageResponse {

--- a/backend/src/user/dto/response/user-history-response.dto.ts
+++ b/backend/src/user/dto/response/user-history-response.dto.ts
@@ -35,7 +35,7 @@ class History {
    * 게임 생성 시간
    * @example '2021-01-01T00:00:00.000Z'
    */
-  createdAt: Date;
+  createdAt: Date | string;
 }
 
 export class UserHistoryResponseDto implements UserHistoryResponse {

--- a/database/create-table.sql
+++ b/database/create-table.sql
@@ -91,7 +91,7 @@ CREATE TABLE public.blocked_user (
 CREATE TABLE public.friendship (
     id integer NOT NULL,
     accept boolean DEFAULT false NOT NULL,
-    last_messege_time timestamp without time zone DEFAULT '-infinity'::timestamp without time zone NOT NULL,
+    last_message_time timestamp without time zone DEFAULT '-infinity'::timestamp without time zone NOT NULL,
     sender_id integer,
     receiver_id integer
 );
@@ -280,7 +280,7 @@ COPY public.blocked_user (user_id, blocked_user_id) FROM stdin;
 -- Data for Name: friendship; Type: TABLE DATA; Schema: public;
 --
 
-COPY public.friendship (id, accept, last_messege_time, sender_id, receiver_id) FROM stdin;
+COPY public.friendship (id, accept, last_message_time, sender_id, receiver_id) FROM stdin;
 \.
 
 

--- a/types/friend/response/friend-response.interface.ts
+++ b/types/friend/response/friend-response.interface.ts
@@ -1,10 +1,10 @@
-import { UserInfo } from "../../user/user-info.interface";
+import { UserInfo } from '../../user/user-info.interface';
 
 export interface FriendResponse {
   friends: {
     id: number;
-    lastMessegeTime: Date | null;
-    lastViewTime: Date | null;
+    lastMessegeTime: Date | string | null;
+    lastViewTime: Date | string | null;
     user: UserInfo;
   }[];
 }

--- a/types/friend/response/friend-response.interface.ts
+++ b/types/friend/response/friend-response.interface.ts
@@ -3,7 +3,7 @@ import { UserInfo } from '../../user/user-info.interface';
 export interface FriendResponse {
   friends: {
     id: number;
-    lastMessegeTime: Date | string | null;
+    lastMessageTime: Date | string | null;
     lastViewTime: Date | string | null;
     user: UserInfo;
   }[];

--- a/types/message/response/message-response.interface.ts
+++ b/types/message/response/message-response.interface.ts
@@ -3,6 +3,6 @@ export interface MessageResponse {
     id: number;
     senderId: number;
     content: string;
-    createdAt: Date;
+    createdAt: Date | string;
   }[];
 }

--- a/types/user/response/user-history-response.interface.ts
+++ b/types/user/response/user-history-response.interface.ts
@@ -7,6 +7,6 @@ export interface UserHistoryResponse {
     loser: UserInfo;
     winnerScore: number;
     loserScore: number;
-    createdAt: Date;
+    createdAt: Date | string;
   }[];
 }


### PR DESCRIPTION
## Summary
- user 1, 2, 3 을 고정적으로 생성하도록 seed 코드 수정
- dto 타입의 `Date` 를 `Date|string` 으로 변경
- messege -> message 로 오타 수정

## Describe your changes
변경된 seed 데이터 사항은 다음과 같습니다.
- 유저 id 1, 2, 3 은 무조건 `REGISTERED` 로 존재 (user table 에 존재)
- friend id 1 은 무조건 존재하며, 1과 2의 친구 관계를 나타냄
- friend id 1 의 메세지 기록은 무조건 존재
- friend id 2 는 무조건 존재하며, 1이 3에게 친구 신청한 관계
- 불규칙하게 생성되던 메세지 데이터를 시간순으로 순차 생성되도록 변경.

## Issue number and link
- close #177