### PR TITLE
✨ [Feature] Apply Guards for user and guest

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,8 @@ import { DatabaseConfigService } from './config/database/configuration.service';
 import { FriendModule } from './friend/friend.module';
 import { MessageModule } from './message/message.module';
 import { UserModule } from './user/user.module';
+import { APP_GUARD } from '@nestjs/core';
+import { UserGuard } from './auth/guard/user.guard';
 
 @Module({
   imports: [
@@ -36,6 +38,6 @@ import { UserModule } from './user/user.module';
     UserModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, { provide: APP_GUARD, useClass: UserGuard }],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,12 +1,14 @@
 import { join } from 'path';
 
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { UserGuard } from './auth/guard/user.guard';
 import { BlockedModule } from './blocked/blocked.module';
 import { AppConfigModule } from './config/app/configuration.module';
 import { DatabaseConfigModule } from './config/database/configuration.module';
@@ -14,8 +16,6 @@ import { DatabaseConfigService } from './config/database/configuration.service';
 import { FriendModule } from './friend/friend.module';
 import { MessageModule } from './message/message.module';
 import { UserModule } from './user/user.module';
-import { APP_GUARD } from '@nestjs/core';
-import { UserGuard } from './auth/guard/user.guard';
 
 @Module({
   imports: [

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get, Res, UseGuards } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
 import { ApiHeaders, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 
@@ -8,6 +7,9 @@ import { AUTH_COOKIE_EXPIREIN } from 'src/common/constant';
 import { AuthService } from './auth.service';
 import { ExtractUser } from './decorator/extract-user.decorator';
 import { LoginInfoDto } from './dto/login-info.dto';
+import { FtGuard } from './guard/ft.guard';
+import { GuestGuard } from './guard/guest.guard';
+import { UserGuard } from './guard/user.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -20,14 +22,14 @@ export class AuthController {
   */
 
   @ApiOperation({ summary: '42 로그인' })
-  @UseGuards(AuthGuard('42')) // strategy.constructor
+  @UseGuards(FtGuard) // strategy.constructor
   @Get('42login')
   login() {
     return;
   }
 
   @ApiOperation({ summary: '42 로그인 callback' })
-  @UseGuards(AuthGuard('42')) // strategy.validate() -> return 값 기반으로 request 객체 담아줌
+  @UseGuards(FtGuard) // strategy.validate() -> return 값 기반으로 request 객체 담아줌
   @Get('42login/callback')
   async callbackLogin(@ExtractUser() user: LoginInfoDto, @Res() res: Response) {
     // 또는 @ReqUser('email') email: string console.log('42 Login Callback!');
@@ -52,20 +54,20 @@ export class AuthController {
 
   // FIXME : delete it (tmp for test)
   // 닉네임 설정하는 페이지로 redirect
-  @UseGuards(AuthGuard('auth'))
+  @UseGuards(GuestGuard)
   @Get('register')
   test2() {
-    console.log('Redirect : auth strategy(tmp jwt) guard success!');
+    console.log('Redirect : Guest Guard success!');
     return 'Redirect to NICKNAME SETTING page!';
   }
 
   // FIXME : delete it (tmp for test)
   // 최종적으로 redirect할 lobby page라고 가정
-  @UseGuards(AuthGuard('user'))
+  @UseGuards(UserGuard)
   @Get()
   test() {
     // test(@Query('token') token: string) {
-    console.log('Redirect : user strategy(jwt) guard success!');
+    console.log('Redirect : User Guard success!');
     // console.log(token);
     return 'Redirect to LOBBY page!';
   }
@@ -73,7 +75,7 @@ export class AuthController {
   // FIXME test
   @ApiOperation({ summary: 'token test' })
   @ApiHeaders([{ name: 'Authorization', description: 'jwt token' }])
-  @UseGuards(AuthGuard('user'))
+  @UseGuards(UserGuard)
   @Get('test')
   tokenTest() {
     console.log('success token test');

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { Response } from 'express';
 import { AUTH_COOKIE_EXPIREIN } from 'src/common/constant';
 
 import { AuthService } from './auth.service';
-import { ExtractUser } from './decorator/auth.decorator';
+import { ExtractUser } from './decorator/extract-user.decorator';
 import { LoginInfoDto } from './dto/login-info.dto';
 
 @ApiTags('auth')
@@ -61,7 +61,7 @@ export class AuthController {
 
   // FIXME : delete it (tmp for test)
   // 최종적으로 redirect할 lobby page라고 가정
-  // @UseGuards(AuthGuard('user'))
+  @UseGuards(AuthGuard('user'))
   @Get()
   test() {
     // test(@Query('token') token: string) {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,13 +3,13 @@ import { ApiHeaders, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 
 import { AUTH_COOKIE_EXPIREIN } from 'src/common/constant';
+import { AppConfigService } from 'src/config/app/configuration.service';
 
 import { AuthService } from './auth.service';
 import { ExtractUser } from './decorator/extract-user.decorator';
+import { SkipUserGuard } from './decorator/skip-user-guard.decorator';
 import { LoginInfoDto } from './dto/login-info.dto';
 import { FtGuard } from './guard/ft.guard';
-import { SkipUserGuard } from './decorator/skip-user-guard.decorator';
-import { AppConfigService } from 'src/config/app/configuration.service';
 import { GuestGuard } from './guard/guest.guard';
 
 @ApiTags('auth')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -40,7 +40,6 @@ export class AuthController {
 
     if (user.id === null) {
       // UNREGSIETERED -> JOIN (sign up)
-      console.log('UNREGISTERED');
       const token = await this.authService.signUp(user);
       res
         .cookie('jwt-for-unregistered', token, {
@@ -53,7 +52,6 @@ export class AuthController {
     } else {
       // REGISTERED -> LOGIN (sign in)
       const token = await this.authService.signIn(user.id);
-      console.log(token);
       res.redirect(`${clientUrl}/auth?token=${token}`);
     }
   }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,13 +8,13 @@ import { Auth } from '../entity/auth.entity';
 
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { AuthStrategy } from './strategy/auth.strategy';
-import { FtOAuthStrategy } from './strategy/ft-oauth.strategy';
+import { FtStrategy } from './strategy/ft.strategy';
+import { GuestStrategy } from './strategy/guest.strategy';
 import { UserStrategy } from './strategy/user.strategy';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Auth]), JwtModule.register({}), FtAuthConfigModule, JwtConfigModule],
-  providers: [AuthService, FtOAuthStrategy, AuthStrategy, UserStrategy],
+  providers: [AuthService, FtStrategy, GuestStrategy, UserStrategy],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,17 +2,18 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AppConfigModule } from 'src/config/app/configuration.module';
+
 import { FtAuthConfigModule } from '../config/auth/ft/configuration.module';
 import { JwtConfigModule } from '../config/auth/jwt/configuration.module';
 import { Auth } from '../entity/auth.entity';
 
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { UserGuard } from './guard/user.guard';
 import { FtStrategy } from './strategy/ft.strategy';
 import { GuestStrategy } from './strategy/guest.strategy';
 import { UserStrategy } from './strategy/user.strategy';
-import { AppConfigModule } from 'src/config/app/configuration.module';
-import { UserGuard } from './guard/user.guard';
 
 @Module({
   imports: [

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -11,10 +11,18 @@ import { AuthService } from './auth.service';
 import { FtStrategy } from './strategy/ft.strategy';
 import { GuestStrategy } from './strategy/guest.strategy';
 import { UserStrategy } from './strategy/user.strategy';
+import { AppConfigModule } from 'src/config/app/configuration.module';
+import { UserGuard } from './guard/user.guard';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Auth]), JwtModule.register({}), FtAuthConfigModule, JwtConfigModule],
-  providers: [AuthService, FtStrategy, GuestStrategy, UserStrategy],
+  imports: [
+    TypeOrmModule.forFeature([Auth]),
+    JwtModule.register({}),
+    FtAuthConfigModule,
+    JwtConfigModule,
+    AppConfigModule,
+  ],
+  providers: [AuthService, FtStrategy, GuestStrategy, UserStrategy, UserGuard],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -32,7 +32,7 @@ export class AuthService {
       secret: this.jwtConfigService.authSecretKey,
       expiresIn: AUTH_JWT_EXPIREIN,
     };
-    return await this.jwtService.sign(payload, signOptions);
+    return this.jwtService.sign(payload, signOptions);
   }
 
   // REGISTERD -> SIGN IN (Login)
@@ -46,6 +46,6 @@ export class AuthService {
       secret: this.jwtConfigService.userSecretKey,
       expiresIn: USER_JWT_EXPIREIN,
     };
-    return await this.jwtService.sign(payload, signOptions);
+    return this.jwtService.sign(payload, signOptions);
   }
 }

--- a/backend/src/auth/decorator/extract-user.decorator.ts
+++ b/backend/src/auth/decorator/extract-user.decorator.ts
@@ -1,4 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { LoginInfoDto } from '../dto/login-info.dto';
 
 /**
  * @description Request 객체에서 user 정보를 추출
@@ -6,7 +7,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
  * @return user : LoginInfoDto
  * @ExtractUser() user: LoginInfoDto 로 사용
  */
-export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext): LoginInfoDto => {
   const request = ctx.switchToHttp().getRequest();
   // TODO undefined error 처리
   return request.user;

--- a/backend/src/auth/decorator/extract-user.decorator.ts
+++ b/backend/src/auth/decorator/extract-user.decorator.ts
@@ -2,6 +2,8 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 /**
  * @description Request 객체에서 user 정보를 추출
+ * @note FtGuard, UserGuard, GuestGuard와 같이 passport 라이브러리 사용할 경우에만 사용
+ * @return user : LoginInfoDto
  * @ExtractUser() user: LoginInfoDto 로 사용
  */
 export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {

--- a/backend/src/auth/decorator/extract-user.decorator.ts
+++ b/backend/src/auth/decorator/extract-user.decorator.ts
@@ -1,8 +1,8 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 /**
- * @description Request 객체에서 user 정보를 가져옴
- * @ExtractUser() user: User 로 사용
+ * @description Request 객체에서 user 정보를 추출
+ * @ExtractUser() user: LoginInfoDto 로 사용
  */
 export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();

--- a/backend/src/auth/decorator/extract-user.decorator.ts
+++ b/backend/src/auth/decorator/extract-user.decorator.ts
@@ -8,5 +8,6 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
  */
 export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();
+  // TODO undefined error 처리
   return request.user;
 });

--- a/backend/src/auth/decorator/skip-user-guard.decorator.ts
+++ b/backend/src/auth/decorator/skip-user-guard.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SkipUserGuard = () => SetMetadata('skipUserGuard', true);

--- a/backend/src/auth/guard/ft.guard.ts
+++ b/backend/src/auth/guard/ft.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable, CanActivate } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class FtGuard extends AuthGuard('ft') implements CanActivate {}

--- a/backend/src/auth/guard/guest.guard.ts
+++ b/backend/src/auth/guard/guest.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable, CanActivate } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class GuestGuard extends AuthGuard('guest') implements CanActivate {}

--- a/backend/src/auth/guard/user.guard.ts
+++ b/backend/src/auth/guard/user.guard.ts
@@ -2,21 +2,20 @@ import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Observable } from 'rxjs';
+
 import { AppConfigService } from 'src/config/app/configuration.service';
 
 @Injectable()
 export class UserGuard extends AuthGuard('user') implements CanActivate {
-  constructor(private reflector: Reflector) //
-  // private readonly appConfigService: AppConfigService) {
-  {
+  constructor(private reflector: Reflector, private readonly appConfigService: AppConfigService) {
     super();
   }
 
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     // 개발 환경에서는 토큰 검증을 하지 않음
-    // if (this.appConfigService.env === 'development') {
-    //   return true;
-    // }
+    if (this.appConfigService.env === 'development') {
+      return true;
+    }
 
     const skipUserGuard = this.reflector.get<boolean>('skipUserGuard', context.getHandler());
     if (skipUserGuard) {

--- a/backend/src/auth/guard/user.guard.ts
+++ b/backend/src/auth/guard/user.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable, CanActivate } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class UserGuard extends AuthGuard('user') implements CanActivate {}

--- a/backend/src/auth/guard/user.guard.ts
+++ b/backend/src/auth/guard/user.guard.ts
@@ -1,5 +1,27 @@
-import { Injectable, CanActivate } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { Observable } from 'rxjs';
+import { AppConfigService } from 'src/config/app/configuration.service';
 
 @Injectable()
-export class UserGuard extends AuthGuard('user') implements CanActivate {}
+export class UserGuard extends AuthGuard('user') implements CanActivate {
+  constructor(private reflector: Reflector) //
+  // private readonly appConfigService: AppConfigService) {
+  {
+    super();
+  }
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    // 개발 환경에서는 토큰 검증을 하지 않음
+    // if (this.appConfigService.env === 'development') {
+    //   return true;
+    // }
+
+    const skipUserGuard = this.reflector.get<boolean>('skipUserGuard', context.getHandler());
+    if (skipUserGuard) {
+      return true;
+    }
+    return super.canActivate(context);
+  }
+}

--- a/backend/src/auth/strategy/ft.strategy.ts
+++ b/backend/src/auth/strategy/ft.strategy.ts
@@ -9,7 +9,7 @@ import { Auth, AuthStatus } from '../../entity/auth.entity';
 import { LoginInfoDto } from '../dto/login-info.dto';
 
 @Injectable()
-export class FtOAuthStrategy extends PassportStrategy(Strategy, '42') {
+export class FtStrategy extends PassportStrategy(Strategy, 'ft') {
   constructor(
     private readonly ftAuthConfigService: FtAuthConfigService,
     @InjectRepository(Auth)

--- a/backend/src/auth/strategy/guest.strategy.ts
+++ b/backend/src/auth/strategy/guest.strategy.ts
@@ -20,7 +20,7 @@ export class GuestStrategy extends PassportStrategy(Strategy, 'guest') {
   }
 
   async validate(payload: JwtPayload) {
-    // console.log("auth strategy's validate");
+    console.log("Guest strategy's validate");
     const token = {
       // email: payload.email,
       userId: payload.userId,

--- a/backend/src/auth/strategy/guest.strategy.ts
+++ b/backend/src/auth/strategy/guest.strategy.ts
@@ -20,7 +20,6 @@ export class GuestStrategy extends PassportStrategy(Strategy, 'guest') {
   }
 
   async validate(payload: JwtPayload) {
-    console.log("Guest strategy's validate");
     const token = {
       // email: payload.email,
       userId: payload.userId,

--- a/backend/src/auth/strategy/guest.strategy.ts
+++ b/backend/src/auth/strategy/guest.strategy.ts
@@ -7,7 +7,7 @@ import { JwtPayload } from '../../common/type/jwt-payload';
 import { JwtConfigService } from '../../config/auth/jwt/configuration.service';
 
 @Injectable()
-export class AuthStrategy extends PassportStrategy(Strategy, 'auth') {
+export class GuestStrategy extends PassportStrategy(Strategy, 'guest') {
   constructor(private readonly jwtConfigService: JwtConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -2,13 +2,13 @@ import {
   Controller,
   Delete,
   Get,
-  Headers,
   HttpCode,
   HttpStatus,
   Param,
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiConflictResponse,
@@ -21,6 +21,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { UserGuard } from '../auth/guard/user.guard';
+import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { CheckUserIdPipe } from '../common/pipe/check-user-id.pipe';
@@ -32,13 +34,14 @@ import { BlockedUserResponseDto } from './dto/response/blocked-user-response.dto
 
 @ApiTags('blocked')
 @Controller('blocked')
+@UseGuards(UserGuard)
 export class BlockedController {
   constructor(private readonly blockedService: BlockedService) {}
   @ApiOperation({ summary: '차단한 유저 목록(정보 포함) 가져오기' })
   @Get()
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
-  getBlockedUserList(@Headers('x-my-id') myId: number): Promise<BlockedUserResponseDto> {
-    return this.blockedService.getBlockedUserList(+myId);
+  getBlockedUserList(@ExtractUserId() myId: number): Promise<BlockedUserResponseDto> {
+    return this.blockedService.getBlockedUserList(myId);
   }
 
   @ApiOperation({ summary: 'nickname으로 유저 차단하기(직접 입력)' })
@@ -50,10 +53,10 @@ export class BlockedController {
   @HttpCode(HttpStatus.OK)
   @Post()
   blockUserByNickname(
-    @Headers('x-my-id') myId: number,
+    @ExtractUserId() myId: number,
     @Query('nickname', NicknameToIdPipe) userId: number,
   ): Promise<SuccessResponseDto> {
-    return this.blockedService.blockUser(+myId, userId);
+    return this.blockedService.blockUser(myId, userId);
   }
 
   @ApiOperation({ summary: 'id로 유저 차단하기(토글->마우스 이용)' })
@@ -64,10 +67,10 @@ export class BlockedController {
   @HttpCode(HttpStatus.OK)
   @Post(':userId')
   blockUserById(
-    @Headers('x-my-id') myId: number,
+    @ExtractUserId() myId: number,
     @Param('userId', NonNegativeIntPipe, CheckUserIdPipe) userId: number,
   ): Promise<SuccessResponseDto> {
-    return this.blockedService.blockUser(+myId, userId);
+    return this.blockedService.blockUser(myId, userId);
   }
 
   @ApiOperation({ summary: '유저 차단 해제' })
@@ -76,9 +79,9 @@ export class BlockedController {
   @ApiParam({ name: 'userId', description: '차단 해제할 사람 아이디' })
   @Delete(':userId')
   deleteBlockedUser(
-    @Headers('x-my-id') myId: number,
+    @ExtractUserId() myId: number,
     @Param('userId', ParseIntPipe) userId: number,
   ): Promise<SuccessResponseDto> {
-    return this.blockedService.deleteBlockedUser(+myId, userId);
+    return this.blockedService.deleteBlockedUser(myId, userId);
   }
 }

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -34,7 +34,6 @@ import { BlockedUserResponseDto } from './dto/response/blocked-user-response.dto
 
 @ApiTags('blocked')
 @Controller('blocked')
-@UseGuards(UserGuard)
 export class BlockedController {
   constructor(private readonly blockedService: BlockedService) {}
   @ApiOperation({ summary: '차단한 유저 목록(정보 포함) 가져오기' })

--- a/backend/src/blocked/blocked.controller.ts
+++ b/backend/src/blocked/blocked.controller.ts
@@ -1,15 +1,4 @@
-import {
-  Controller,
-  Delete,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Param,
-  ParseIntPipe,
-  Post,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -21,7 +10,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
-import { UserGuard } from '../auth/guard/user.guard';
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';

--- a/backend/src/common/decorator/extract-user-id.decorator.ts
+++ b/backend/src/common/decorator/extract-user-id.decorator.ts
@@ -7,12 +7,12 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
  * @return userId : number
  * @ExtractUserId() userId: number 로 사용
  */
-export const ExtractUserId = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+export const ExtractUserId = createParamDecorator((data: unknown, ctx: ExecutionContext): number => {
   const request = ctx.switchToHttp().getRequest();
 
   // 개발 환경에서는 headers에 있는 x-my-id를 userId로 사용
   if (process.env.NODE_ENV === 'development') {
-    return request.headers['x-my-id'];
+    return +request.headers['x-my-id'];
   }
 
   // TODO undefined error 처리

--- a/backend/src/common/decorator/extract-user-id.decorator.ts
+++ b/backend/src/common/decorator/extract-user-id.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**
+ * @description token의 userId 추출
+ * @ExtractUserId() userId: number 로 사용
+ */
+export const ExtractUserId = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest();
+  return request.user.userId;
+});

--- a/backend/src/common/decorator/extract-user-id.decorator.ts
+++ b/backend/src/common/decorator/extract-user-id.decorator.ts
@@ -11,10 +11,9 @@ export const ExtractUserId = createParamDecorator((data: unknown, ctx: Execution
   const request = ctx.switchToHttp().getRequest();
 
   // 개발 환경에서는 headers에 있는 x-my-id를 userId로 사용
-  // const appConfigService = new AppConfigService();
-  // if (process.env.NODE_ENV === 'development') {
-  //   return request.headers['x-my-id'];
-  // }
+  if (process.env.NODE_ENV === 'development') {
+    return request.headers['x-my-id'];
+  }
 
   // TODO undefined error 처리
   return request.user.userId;

--- a/backend/src/common/decorator/extract-user-id.decorator.ts
+++ b/backend/src/common/decorator/extract-user-id.decorator.ts
@@ -2,6 +2,8 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 /**
  * @description token의 userId 추출
+ * @note FtGuard, UserGuard, GuestGuard 있을 경우에만 사용
+ * @return userId : number
  * @ExtractUserId() userId: number 로 사용
  */
 export const ExtractUserId = createParamDecorator((data: unknown, ctx: ExecutionContext) => {

--- a/backend/src/common/decorator/extract-user-id.decorator.ts
+++ b/backend/src/common/decorator/extract-user-id.decorator.ts
@@ -1,4 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+// import { AppConfigService } from 'src/config/app/configuration.service';
 
 /**
  * @description token의 userId 추출
@@ -8,5 +9,13 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
  */
 export const ExtractUserId = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();
+
+  // 개발 환경에서는 headers에 있는 x-my-id를 userId로 사용
+  // const appConfigService = new AppConfigService();
+  // if (process.env.NODE_ENV === 'development') {
+  //   return request.headers['x-my-id'];
+  // }
+
+  // TODO undefined error 처리
   return request.user.userId;
 });

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -99,7 +99,6 @@ export class FriendController {
     @ExtractUserId() myId: number,
     @Param('userId', NonNegativeIntPipe, CheckUserIdPipe) userId: number,
   ): Promise<SuccessResponseDto> {
-    // FIXME: myId 임시 헤더라서 + 갈겼습니다...
     return this.friendService.rejectFriendRequest(userId, myId);
   }
 }

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -10,7 +10,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
-import { UserGuard } from '../auth/guard/user.guard';
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -1,15 +1,4 @@
-import {
-  Controller,
-  Delete,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Param,
-  ParseIntPipe,
-  Post,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
 import {
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -35,7 +24,6 @@ import { FriendService } from './friend.service';
 
 @ApiTags('friend')
 @Controller('friend')
-@UseGuards(UserGuard)
 export class FriendController {
   constructor(private readonly friendService: FriendService) {}
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,8 @@
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import * as cookieParser from 'cookie-parser';
 import { ValidationError } from 'class-validator';
+import * as cookieParser from 'cookie-parser';
 
 import { AppModule } from './app.module';
 import { AppConfigService } from './config/app/configuration.service';

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, Headers, DefaultValuePipe, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, DefaultValuePipe, UseGuards } from '@nestjs/common';
 import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 
 import { UserGuard } from '../auth/guard/user.guard';
@@ -11,7 +11,6 @@ import { MessageService } from './message.service';
 
 @ApiTags('message')
 @Controller('message')
-@UseGuards(UserGuard)
 export class MessageController {
   constructor(private readonly messageService: MessageService) {}
 

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Param, Query, Headers, DefaultValuePipe } from '@nestjs/common';
+import { Controller, Get, Param, Query, Headers, DefaultValuePipe, UseGuards } from '@nestjs/common';
 import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 
+import { UserGuard } from '../auth/guard/user.guard';
+import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { NonNegativeIntPipe } from '../common/pipe/non-negative-int.pipe';
 
@@ -9,6 +11,7 @@ import { MessageService } from './message.service';
 
 @ApiTags('message')
 @Controller('message')
+@UseGuards(UserGuard)
 export class MessageController {
   constructor(private readonly messageService: MessageService) {}
 
@@ -19,10 +22,10 @@ export class MessageController {
   @ApiQuery({ name: 'offset', required: false, description: '마지막으로 가져온 메시지의 id' })
   @Get(':friendId')
   getMessagesList(
+    @ExtractUserId() myId: number,
     @Param('friendId', NonNegativeIntPipe) friendId: number,
     @Query('offset', new DefaultValuePipe(0), NonNegativeIntPipe) offset: number,
-    @Headers('x-my-id') myId: number,
   ): Promise<MessageResponseDto> {
-    return this.messageService.getMessagesList(+myId, friendId, offset);
+    return this.messageService.getMessagesList(myId, friendId, offset);
   }
 }

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,7 +1,6 @@
-import { Controller, Get, Param, Query, DefaultValuePipe, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, DefaultValuePipe } from '@nestjs/common';
 import { ApiHeaders, ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 
-import { UserGuard } from '../auth/guard/user.guard';
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { NonNegativeIntPipe } from '../common/pipe/non-negative-int.pipe';

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -29,11 +29,14 @@ import {
 } from '@nestjs/swagger';
 import { Response } from 'express';
 
+import { SkipUserGuard } from '../auth/decorator/skip-user-guard.decorator';
+import { GuestGuard } from '../auth/guard/guest.guard';
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { CheckUserIdPipe } from '../common/pipe/check-user-id.pipe';
 import { NonNegativeIntPipe } from '../common/pipe/non-negative-int.pipe';
+import { AppConfigService } from '../config/app/configuration.service';
 
 import { UserImageRequestDto } from './dto/request/user-image-request.dto';
 import { UserNicknameRequestDto } from './dto/request/user-nickname-request.dto';
@@ -43,9 +46,6 @@ import { UserNicknameResponseDto } from './dto/response/user-nickname-response.d
 import { UserProfileResponseDto } from './dto/response/user-profile-response.dto';
 import { FileUploadInterceptor } from './interceptor/file-upload.interceptor';
 import { UserService } from './user.service';
-import { SkipUserGuard } from '../auth/decorator/skip-user-guard.decorator';
-import { GuestGuard } from '../auth/guard/guest.guard';
-import { AppConfigService } from '../config/app/configuration.service';
 
 @ApiTags('user')
 @Controller('user')
@@ -66,17 +66,17 @@ export class UserController {
     description: '중복된 nickname 또는 이미 생성된 user(중복된 auth-id), 이미 registered인 유저',
   })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: 'Invalid한 auth-id' })
-  @ApiHeaders([{ name: 'x-auth-id', description: '내 auth 아이디 (임시값)' }])
+  @ApiHeaders([{ name: 'x-my-id', description: '내 auth 아이디 (임시값)' }])
   @HttpCode(HttpStatus.OK)
   @SkipUserGuard()
   @UseGuards(GuestGuard)
   @Post()
   async createUser(
-    @ExtractUserId() authId: number,
+    @ExtractUserId() myId: number,
     @Body() { nickname }: UserNicknameRequestDto,
     @Res() res: Response,
   ): Promise<void> {
-    const token = await this.userService.createUser(authId, nickname);
+    const token = await this.userService.createUser(myId, nickname);
     const clientUrl = this.appConfigService.clientUrl;
 
     res.clearCookie('jwt-for-unregistered').redirect(`${clientUrl}/auth?token=${token}`);

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   DefaultValuePipe,
   Get,
-  Headers,
   HttpCode,
   HttpStatus,
   Param,
@@ -13,6 +12,7 @@ import {
   Query,
   Res,
   UploadedFile,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import {
@@ -30,6 +30,8 @@ import {
 } from '@nestjs/swagger';
 import { Response } from 'express';
 
+import { UserGuard } from '../auth/guard/user.guard';
+import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { CheckUserIdPipe } from '../common/pipe/check-user-id.pipe';
@@ -46,6 +48,7 @@ import { UserService } from './user.service';
 
 @ApiTags('user')
 @Controller('user')
+@UseGuards(UserGuard)
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
@@ -53,7 +56,7 @@ export class UserController {
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @Get()
-  getUserInfo(@Headers('x-my-id') myId: number): Promise<UserInfoResponseDto> {
+  getUserInfo(@ExtractUserId() myId: number): Promise<UserInfoResponseDto> {
     return this.userService.getUserInfo(myId);
   }
 
@@ -67,7 +70,7 @@ export class UserController {
   @HttpCode(HttpStatus.OK)
   @Post()
   async createUser(
-    @Headers('x-auth-id') authId: number,
+    @ExtractUserId('x-auth-id') authId: number,
     @Body() { nickname }: UserNicknameRequestDto,
     @Res() res: Response,
   ): Promise<void> {
@@ -96,7 +99,7 @@ export class UserController {
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @Patch('image')
   updateUserProfileImage(
-    @Headers('x-my-id') myId: number,
+    @ExtractUserId() myId: number,
     @Body() updateImageRequestDto: UserImageRequestDto,
   ): Promise<SuccessResponseDto> {
     return this.userService.updateUserImage(myId, updateImageRequestDto.image);
@@ -107,7 +110,7 @@ export class UserController {
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @Patch('nickname')
   updateUserNickname(
-    @Headers('x-my-id') myId: number,
+    @ExtractUserId() myId: number,
     @Body() updateNicknameDto: UserNicknameRequestDto,
   ): Promise<UserNicknameResponseDto> {
     return this.userService.updateUserNickname(myId, updateNicknameDto.nickname);

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -9,9 +9,14 @@ import { User } from '../entity/user.entity';
 
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { AppConfigModule } from 'src/config/app/configuration.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Achievement, UserRecord, GameHistory]), forwardRef(() => AuthModule)],
+  imports: [
+    TypeOrmModule.forFeature([User, Achievement, UserRecord, GameHistory]),
+    forwardRef(() => AuthModule),
+    AppConfigModule,
+  ],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,6 +1,8 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AppConfigModule } from 'src/config/app/configuration.module';
+
 import { AuthModule } from '../auth/auth.module';
 import { Achievement } from '../entity/achievement.entity';
 import { GameHistory } from '../entity/game-history.entity';
@@ -9,7 +11,6 @@ import { User } from '../entity/user.entity';
 
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
-import { AppConfigModule } from 'src/config/app/configuration.module';
 
 @Module({
   imports: [

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -43,7 +43,6 @@ export class UserService {
   }
 
   async createUser(myId: number, nickname: string): Promise<string> {
-    // await this.authService.checkExistAuthId(myId); // FIXME : guard
     await this.checkAlreadyExistUser(myId); // user 이미 있으면 에러
     await this.checkDuplicatedNickname(nickname);
     await this.userRepository.manager.transaction(async (manager: EntityManager) => {

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -42,15 +42,15 @@ export class UserService {
     };
   }
 
-  async createUser(authId: number, nickname: string): Promise<string> {
-    // await this.authService.checkExistAuthId(authId); // FIXME : guard
-    await this.checkAlreadyExistUser(authId); // user 이미 있으면 에러
+  async createUser(myId: number, nickname: string): Promise<string> {
+    // await this.authService.checkExistAuthId(myId); // FIXME : guard
+    await this.checkAlreadyExistUser(myId); // user 이미 있으면 에러
     await this.checkDuplicatedNickname(nickname);
     await this.userRepository.manager.transaction(async (manager: EntityManager) => {
-      await manager.insert('users', { id: authId, nickname: nickname });
-      await manager.update('auth', { id: authId }, { status: AuthStatus.REGISTERD });
+      await manager.insert('users', { id: myId, nickname: nickname });
+      await manager.update('auth', { id: myId }, { status: AuthStatus.REGISTERD });
     });
-    return await this.authService.signIn(authId);
+    return await this.authService.signIn(myId);
   }
 
   async updateUserImage(myId: number, imageUrl: string): Promise<SuccessResponseDto> {


### PR DESCRIPTION
## Summary
- 로그인 관련한 Guard 적용

## Describe your changes
### Guards
- 기존 AuthGuard 수정
  - `AuthGuard('ft')` -> `FtGuard`
  - `AuthGuard('user')` -> `UserGuard`
  - `AuthGuard('auth')` -> `GuestGuard`
- `UserGuard` 전역 가드로 적용
  - development 단계에서 user guard 항상 true return
- UserGuard skip하는 `@SkipUserGuard` 생성

### token에서 userId 반환하는 custom decorator(`@ExtractUserId`)
- `@Headers` 대신 `@ExtractUserId`로 수정
  - 개발 단계에서 사용할 `x-my-id`는  `@ExtractUserId`에 내부적으로 추가함

### 테스트
- development 단계에서 token 없어도 테스트 가능한 것 확인 (header에 'x-my-id'로 테스트하기)
![image](https://user-images.githubusercontent.com/33301153/236464721-82e840ed-2813-485b-969b-ddcb2ac056c9.png)


## Issue number and link
- #138 