### PR TITLE
:hammer: [refactor] Delete double check for exist user

### DIFF
--- a/backend/src/auth/decorator/extract-user.decorator.ts
+++ b/backend/src/auth/decorator/extract-user.decorator.ts
@@ -1,4 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
 import { LoginInfoDto } from '../dto/login-info.dto';
 
 /**

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Inject, Injectable, NotFoundException, forwardRef } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 
@@ -116,10 +116,7 @@ export class UserService {
       .select(['user', 'blockedUser.blockedUserId'])
       .where('user.id = :id', { id: userId })
       .getOne();
-    if (user === null) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
-    }
-    return user;
+    return user!;
   }
 
   private async findExistUserProfile(userId: number): Promise<User> {
@@ -130,9 +127,6 @@ export class UserService {
       .select(['user', 'userRecord', 'achievement'])
       .where('user.id = :userId', { userId: userId })
       .getOne();
-    if (user === null) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
-    }
-    return user;
+    return user!;
   }
 }


### PR DESCRIPTION
## Summary
- 존재하는 유저에 대한 double check 삭제

## Describe your changes
- `ExtractUserId` decorator로 token에 담긴 userId를 사용하고 있음
- 이미 token으로 존재하는 유저임을 인증되었기 때문에 service 함수 내에서 중복 확인하는 로직 삭제

## Issue number and link
- #218 