### PR TITLE
:hammer: [Refactor] Modify UserGuard when 'development'

### DIFF
--- a/backend/src/auth/guard/user.guard.ts
+++ b/backend/src/auth/guard/user.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Observable } from 'rxjs';
 
-import { AppConfigService } from 'src/config/app/configuration.service';
+import { AppConfigService } from '../../config/app/configuration.service';
 
 @Injectable()
 export class UserGuard extends AuthGuard('user') implements CanActivate {
@@ -14,6 +14,12 @@ export class UserGuard extends AuthGuard('user') implements CanActivate {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     // 개발 환경에서는 토큰 검증을 하지 않음
     if (this.appConfigService.env === 'development') {
+      const request = context.switchToHttp().getRequest();
+      const userId = +request.headers['x-my-id'];
+
+      request.user = {
+        userId: userId,
+      };
       return true;
     }
 

--- a/backend/src/common/decorator/extract-user-id.decorator.ts
+++ b/backend/src/common/decorator/extract-user-id.decorator.ts
@@ -10,11 +10,5 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 export const ExtractUserId = createParamDecorator((data: unknown, ctx: ExecutionContext): number => {
   const request = ctx.switchToHttp().getRequest();
 
-  // 개발 환경에서는 headers에 있는 x-my-id를 userId로 사용
-  if (process.env.NODE_ENV === 'development') {
-    return +request.headers['x-my-id'];
-  }
-
-  // TODO undefined error 처리
   return request.user.userId;
 });


### PR DESCRIPTION
## Summary
- 'development' 일 때 Guard에서 request.user에 userId 담아주기

## Describe your changes
- `ExtractUserId` 에서는 `NODE_ENV`가 'development'인지 확인하지 않음
- `UserGuard`에서 'development'이면 'x-my-id' 값을 `request.user`에 `userId`로 담아줌

## Issue number and link
- #254 