### PR TITLE
✨ [Feature] Two Factor Authenticaion verification API

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Post, Res, UseGuards } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiConflictResponse,
   ApiForbiddenResponse,
   ApiHeaders,
@@ -83,7 +84,8 @@ export class AuthController {
   @ApiOperation({ summary: '2단계 인증 코드 검증하기' })
   @ApiNotFoundResponse({ type: ErrorResponseDto, description: '유저 없음' })
   @ApiConflictResponse({ type: ErrorResponseDto, description: '중복된 이메일 혹은 이미 인증 완료한 유저' })
-  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '2단계 인증 코드가 일치하지 않음' })
+  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '유효하지 않은 인증 코드' })
+  @ApiBadRequestResponse({ type: ErrorResponseDto, description: '잘못된 2단계 인증 코드' })
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @HttpCode(HttpStatus.OK)
   @UseGuards(UserGuard)

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,5 @@
-import { CacheModule, Module } from '@nestjs/common';
+import { CacheModule } from '@nestjs/cache-manager';
+import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MailerModule } from '@nestjs-modules/mailer';

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -76,7 +76,7 @@ export class AuthService {
   }
 
   async verifyTwoFactorAuth(myId: number, code: string) {
-    const auth = await this.authRepository.findOneBy({ id: myId });
+    const auth = await this.authRepository.findOne({ where: { id: myId }, select: ['twoFa'] });
     if (auth !== null) {
       throw new ConflictException('이미 2단계 인증이 완료된 유저입니다.');
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -77,7 +77,7 @@ export class AuthService {
 
   async verifyTwoFactorAuth(myId: number, code: string) {
     const auth = await this.authRepository.findOneBy({ id: myId });
-    if (auth?.twoFa !== null) {
+    if (auth !== null) {
       throw new ConflictException('이미 2단계 인증이 완료된 유저입니다.');
     }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -57,7 +57,7 @@ export class AuthService {
 
   async twoFactorAuth(myId: number, email: string) {
     const myTwoFa = await this.authRepository.findOne({ where: { id: myId }, select: ['twoFa'] });
-    if (myTwoFa !== null && myTwoFa.twoFa !== '') {
+    if (myTwoFa !== null) {
       throw new ConflictException('이미 인증이 완료된 유저입니다.');
     }
     if ((await this.authRepository.findOneBy({ twoFa: email })) !== null) {
@@ -77,7 +77,7 @@ export class AuthService {
 
   async verifyTwoFactorAuth(myId: number, code: string) {
     const auth = await this.authRepository.findOneBy({ id: myId });
-    if (auth !== null && auth.twoFa !== '') {
+    if (auth !== null) {
       throw new ConflictException('이미 2단계 인증이 완료된 유저입니다.');
     }
 

--- a/backend/src/auth/decorator/extract-user.decorator.ts
+++ b/backend/src/auth/decorator/extract-user.decorator.ts
@@ -1,14 +1,14 @@
 import { BadRequestException, createParamDecorator, ExecutionContext } from '@nestjs/common';
 
-import { LoginInfoDto } from '../dto/login-info.dto';
+import { LoginInfo } from '../type/login-info';
 
 /**
  * @description Request 객체에서 user 정보를 추출
  * @note FtGuard, UserGuard, GuestGuard와 같이 passport 라이브러리 사용할 경우에만 사용
- * @return user : LoginInfoDto
- * @ExtractUser() user: LoginInfoDto 로 사용
+ * @return user : LoginInfo
+ * @ExtractUser() user: LoginInfo 로 사용
  */
-export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext): LoginInfoDto => {
+export const ExtractUser = createParamDecorator((data: unknown, ctx: ExecutionContext): LoginInfo => {
   const request = ctx.switchToHttp().getRequest();
 
   if (request.user === undefined) {

--- a/backend/src/auth/dto/request/code-verification-request.dto.ts
+++ b/backend/src/auth/dto/request/code-verification-request.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
+
+import { CodeVerificationRequest } from '@/types/auth/request';
+
+export class CodeVerificationRequestDto implements CodeVerificationRequest {
+  /**
+   * 2단계 인증 코드
+   * @example '123456'
+   */
+  @IsNotEmpty()
+  @IsNumberString()
+  @Length(6, 6)
+  code: string;
+}

--- a/backend/src/auth/dto/request/code-verification-request.dto.ts
+++ b/backend/src/auth/dto/request/code-verification-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
+import { IsNumberString, Length } from 'class-validator';
 
 import { CodeVerificationRequest } from '@/types/auth/request';
 
@@ -7,7 +7,6 @@ export class CodeVerificationRequestDto implements CodeVerificationRequest {
    * 2단계 인증 코드
    * @example '123456'
    */
-  @IsNotEmpty()
   @IsNumberString()
   @Length(6, 6)
   code: string;

--- a/backend/src/auth/strategy/ft.strategy.ts
+++ b/backend/src/auth/strategy/ft.strategy.ts
@@ -6,7 +6,7 @@ import { Repository } from 'typeorm';
 
 import { FtAuthConfigService } from '../../config/auth/ft/configuration.service';
 import { Auth, AuthStatus } from '../../entity/auth.entity';
-import { LoginInfoDto } from '../dto/login-info.dto';
+import { LoginInfo } from '../type/login-info';
 
 @Injectable()
 export class FtStrategy extends PassportStrategy(Strategy, 'ft') {
@@ -34,7 +34,7 @@ export class FtStrategy extends PassportStrategy(Strategy, 'ft') {
    * @param cb  validate()에서 return한 값이 request 객체에 담김
    * @returns  validate()에서 return한 값
    */
-  async validate(accessToken: string, refreshToken: string, profile: LoginInfoDto) {
+  async validate(accessToken: string, refreshToken: string, profile: LoginInfo) {
     const auth = await this.authRepository.findOneBy({ email: profile.email });
 
     // if (auth === null || (await this.userRepository.findOneBy({ id: auth.id })) === null) {

--- a/backend/src/auth/type/login-info.ts
+++ b/backend/src/auth/type/login-info.ts
@@ -1,6 +1,6 @@
 import { IsEmail, IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
 
-export class LoginInfoDto {
+export class LoginInfo {
   /**
    * 42에서 받아온 email
    */

--- a/backend/src/auth/type/two-factor-auth.ts
+++ b/backend/src/auth/type/two-factor-auth.ts
@@ -1,0 +1,4 @@
+export type TwoFactorAuth = {
+  email: string;
+  code: string;
+};

--- a/backend/src/entity/auth.entity.ts
+++ b/backend/src/entity/auth.entity.ts
@@ -13,8 +13,8 @@ export class Auth {
   @Column({ length: 320, unique: true })
   email: string;
 
-  @Column({ length: 320, nullable: true })
-  twoFa: string;
+  @Column({ type: 'varchar', length: 320, nullable: true })
+  twoFa: string | null;
 
   @Column({
     type: 'enum',

--- a/types/auth/request/code-verification-request.interface.ts
+++ b/types/auth/request/code-verification-request.interface.ts
@@ -1,0 +1,3 @@
+export interface CodeVerificationRequest {
+	code: string;
+}

--- a/types/auth/request/code-verification-request.interface.ts
+++ b/types/auth/request/code-verification-request.interface.ts
@@ -1,3 +1,3 @@
 export interface CodeVerificationRequest {
-	code: string;
+  code: string;
 }

--- a/types/auth/request/index.ts
+++ b/types/auth/request/index.ts
@@ -1,1 +1,2 @@
 export { TwoFactorAuthRequest } from "./two-factor-auth-request.interface";
+export { CodeVerificationRequest } from "./code-verification-request.interface";


### PR DESCRIPTION
## Summary
- 2단계 인증 코드 검증하는 API

## Describe your changes
- 기존 `LoginInfoDto`를 `LoginInfo`로 수정하고 `auth/type/`으로 옮겼습니다.
- `auth/type`에 Cache에서 value로 사용할 type `TwoFactorAuth` 추가했습니다.
### 검증 로직
- 이미 2단계 인증 완료한 유저인지 확인
- `Cache에` 있는지 확인 (유효한 인증코드인지 확인)
- 중복된 이메일인지 확인
- `Cache에` 있는 코드와 일치하는지 확인
- `auth`의 `twoFa` column 업데이트
- `Cache`에서 삭제

### 인증 성공한 경우 테스트
<img src="https://github.com/GhostPangPang/GhostPong/assets/33301153/ff2ba8dd-6cfe-4cbc-b7f0-a76d91935468" width="400" height="300">

### 인증 실패한 경우 테스트
<img src="https://github.com/GhostPangPang/GhostPong/assets/33301153/738229bb-ccb9-4428-8708-48485fb84419" width="400" height="300">
<img src="https://github.com/GhostPangPang/GhostPong/assets/33301153/f2fae204-cc2e-471a-85ed-bdf638d65ae9" width="400" height="300">
<img src="https://github.com/GhostPangPang/GhostPong/assets/33301153/35e47771-72eb-4519-9510-3c7d1ec5179e" width="400" height="300">


## Issue number and link
- #209 