### PR TITLE
✨ [Feature] Add 2fa delete API

### DIFF
--- a/backend/seeding/factory/auth.factory.ts
+++ b/backend/seeding/factory/auth.factory.ts
@@ -8,4 +8,5 @@ export default () => ({
   //auth.id is auto generated
   status: faker.datatype.boolean() && faker.datatype.boolean() ? AuthStatus.UNREGISTERD : AuthStatus.REGISTERD,
   email: faker.internet.email(),
+  twoFa: faker.datatype.boolean() && faker.datatype.boolean() ? faker.internet.email() : undefined,
 });

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Post, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Post, Res, UseGuards } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiConflictResponse,
@@ -92,5 +92,14 @@ export class AuthController {
   @Post('2fa/verify')
   verifyTwoFactorAuth(@ExtractUserId() myId: number, @Body() { code }: CodeVerificationRequestDto) {
     return this.authService.verifyTwoFactorAuth(myId, code);
+  }
+
+  @ApiOperation({ summary: '2단계 인증 삭제하기' })
+  @ApiConflictResponse({ type: ErrorResponseDto, description: '2단계 인증하지 않은 유저' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @UseGuards(UserGuard)
+  @Delete('2fa')
+  deleteTwoFactorAuth(@ExtractUserId() myId: number) {
+    return this.authService.deleteTwoFactorAuth(myId);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -99,6 +99,15 @@ export class AuthService {
   }
 
   // SECTION private
+  async deleteTwoFactorAuth(myId: number) {
+    const auth = await this.authRepository.findOne({ where: { id: myId }, select: ['twoFa'] });
+    if (auth === null || auth.twoFa === '') {
+      throw new ConflictException('2단계 인증 이메일이 없습니다.');
+    }
+    await this.authRepository.update({ id: myId }, { twoFa: '' });
+    return { message: '2단계 인증 이메일이 삭제되었습니다.' };
+  }
+
   private getEmailTemplate(code: string) {
     return `
     <!DOCTYPE html>

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -101,10 +101,10 @@ export class AuthService {
   // SECTION private
   async deleteTwoFactorAuth(myId: number) {
     const auth = await this.authRepository.findOne({ where: { id: myId }, select: ['twoFa'] });
-    if (auth === null || auth.twoFa === '') {
+    if (auth === null) {
       throw new ConflictException('2단계 인증 이메일이 없습니다.');
     }
-    await this.authRepository.update({ id: myId }, { twoFa: '' });
+    await this.authRepository.update({ id: myId }, { twoFa: null });
     return { message: '2단계 인증 이메일이 삭제되었습니다.' };
   }
 


### PR DESCRIPTION
## Summary
- 2fa 이메일 삭제 API

## Describe your changes
- `twoFa` column이 nullable 하지만 삭제할 때 `null`로 저장이 불가능.. 그래서 `''` 로 값 update
  - 자세한 내용은 [여기](https://www.notion.so/62e181f2f7904be9bbd95c9996f40f5b?v=f0730e2561194222b354c04a1f83abee&p=91cd36f9f16c4015a20d3333bd3dedb7&pm=s)를 참고해주세요
  - 라고 했으나 해결법을 알려주셔서 null로 저장합니다!

### 성공 테스트
<img src="https://github.com/GhostPangPang/GhostPong/assets/33301153/3e87254a-7c29-4a25-a6f3-fa9955377d9c" width="400" height="300">


### 실패 테스트
<img src="https://github.com/GhostPangPang/GhostPong/assets/33301153/c838e877-6f3e-4e2a-a338-f907e0614145" width="400" height="300">

## Issue number and link
- #230 