### PR TITLE
:hammer: [Refactor] Add createdAt, receiverId in messageDto 

### DIFF
--- a/backend/src/friend/friend.gateway.ts
+++ b/backend/src/friend/friend.gateway.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
-import { ConnectedSocket, SubscribeMessage, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
-import { Server, Socket } from 'socket.io';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
 import { Repository } from 'typeorm';
 
 import { corsOption } from '../common/option/cors.option';
@@ -17,30 +17,6 @@ export class FriendGateway {
     @InjectRepository(Friendship)
     private readonly friendshipRepository: Repository<Friendship>,
   ) {}
-
-  /**
-   * 친구 창에 들어왔을 때 모든 친구와의 friend room 에 join 한다.
-   *
-   * @param socket 이벤트를 보낸 유저의 소켓
-   */
-  @SubscribeMessage('join-friend-room')
-  async joinFriendRoom(@ConnectedSocket() socket: Socket): Promise<void> {
-    (await this.findFriendsId(socket.data.userId)).map(({ id }) => {
-      socket.join(`friend-${id}`);
-    });
-  }
-
-  /**
-   * 친구 창을 나갔을 때 모든 친구와의 friend room 에서 leave 한다.
-   *
-   * @param socket 이벤트를 보낸 유저의 소켓
-   */
-  @SubscribeMessage('leave-friend-room')
-  async leaveFriendRoom(@ConnectedSocket() socket: Socket): Promise<void> {
-    (await this.findFriendsId(socket.data.userId)).map(({ id }) => {
-      socket.leave(`friend-${id}`);
-    });
-  }
 
   /**
    * 친구 요청이 수락되었을 때 친구 요청을 보낸 유저에게 이벤트를 보낸다.
@@ -63,15 +39,6 @@ export class FriendGateway {
   }
 
   // SECTION: private
-  private findFriendsId(userId: number): Promise<Friendship[]> {
-    return this.friendshipRepository.find({
-      select: ['id'],
-      where: [
-        { senderId: userId, accept: true },
-        { receiverId: userId, accept: true },
-      ],
-    });
-  }
 
   //!SECTION: private
 }

--- a/backend/src/message/dto/socket/message.dto.ts
+++ b/backend/src/message/dto/socket/message.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsNumber, IsString, Max, MaxLength, Min } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsNumber, IsString, Max, MaxLength, Min } from 'class-validator';
 
 import { Message } from '@/types/message/socket';
 
@@ -12,6 +12,23 @@ export class MesssageDto implements Message {
   @Min(1)
   @Max(2147483647)
   id: number;
+
+  /**
+   * @description 메시지 받을 사람 아이디
+   * @example 4
+   */
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(1)
+  @Max(2147483647)
+  receiverId: number;
+
+  /**
+   * @description 메시지 보낸 시간
+   * @example '2021-08-01T00:00:00'
+   */
+  @IsDateString()
+  createdAt: Date | string;
 
   /**
    * @description 메시지 내용

--- a/types/message/socket/message.interface.ts
+++ b/types/message/socket/message.interface.ts
@@ -1,4 +1,6 @@
 export interface Message {
   id: number;
+  receiverId: number;
+  createdAt: Date | string;
   content: string;
 }


### PR DESCRIPTION
## Summary
- `createdAt`, `receiverId`를 `messageDto` 및 message `type`에 추가했습니다.
- `receiverId`를 이용해서 socketId로 보내는 로직 구성했습니다.
- dto로 받은 `createdAt`으로 message entity를 db에 저장합니다.

## Describe your changes
- `createdAt` : 페이지 구성할 때 필요하다는 요청 발생하여 추가했습니다. 
- `receiverId` : 클라이언트에서 보내줄 수 있고 해당 값이 있으면 서버에서 socket room을 만들지 않아도 됨, room으로 인해 생겼던 event 삭제 가능해서 반영했습니다. 

- 친구 관계로 socket room을 만들어 메세지를 보내는 로직이 삭제되면서 dto의 친구 관계 아이디의 유효성을 검사해야하나 고민했는데요.
`friendId`의 유효성을 검사한다면 고려해야할 점이 2가지 있다고 생각했습니다. 
1. blocked 되어서 메세지 씹혀야 하는 경우
2. 그냥 유효하지 않은 친구인 경우 
`1`에 대해서는 프론트에서 blocked 리스트 가지고 있어서 그냥 이벤트 받아서 잘 처리해주기로 해서 고려하지 않아도 됩니다.  
그럼 `2`가 남는데 소켓 통신이니까 빠르게 동작하는 걸 멈출만큼 필요한가 를 중점으로 생각했습니다. db를 다녀오려면 `await`를 거니까요. 그런데 어차피 이 이벤트를 발생할 때는 프론트에서 메세지 페이지에서 가지고 있는 친구데이터로 `friendId`를 넣어서 event 보내게 됩니다. 즉, 정상적인 `ui`로 동작시켰다면 일어나지 않을 일인거죠! 유효하지않은 값을 넣어서 보내려면 소켓 `connect`시 부터 `access token`이 털린 경우이므로 db까지 다녀올 필요가 없다고 생각해서 넣지 않았습니다!! 

## Issue number and link
- close #299 