### PR TITLE
:bug: [Fix] Modify nickname response to SuccessResponseDto

### DIFF
--- a/backend/src/user/dto/response/user-nickname-response.dto.ts
+++ b/backend/src/user/dto/response/user-nickname-response.dto.ts
@@ -1,9 +1,0 @@
-import { UserNicknameResponse } from '@/types/user/response';
-
-export class UserNicknameResponseDto implements UserNicknameResponse {
-  /**
-   * nickname
-   * @example 'san1'
-   */
-  nickname: string;
-}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -43,7 +43,6 @@ import { UserImageRequestDto } from './dto/request/user-image-request.dto';
 import { UserNicknameRequestDto } from './dto/request/user-nickname-request.dto';
 import { UserHistoryResponseDto } from './dto/response/user-history-response.dto';
 import { UserInfoResponseDto } from './dto/response/user-info-response.dto';
-import { UserNicknameResponseDto } from './dto/response/user-nickname-response.dto';
 import { UserProfileResponseDto } from './dto/response/user-profile-response.dto';
 import { FileUploadInterceptor } from './interceptor/file-upload.interceptor';
 import { UserService } from './user.service';
@@ -119,7 +118,7 @@ export class UserController {
   updateUserNickname(
     @ExtractUserId() myId: number,
     @Body() updateNicknameDto: UserNicknameRequestDto,
-  ): Promise<UserNicknameResponseDto> {
+  ): Promise<SuccessResponseDto> {
     return this.userService.updateUserNickname(myId, updateNicknameDto.nickname);
   }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -11,7 +11,6 @@ import { User } from '../entity/user.entity';
 
 import { UserHistoryResponseDto } from './dto/response/user-history-response.dto';
 import { UserInfoResponseDto } from './dto/response/user-info-response.dto';
-import { UserNicknameResponseDto } from './dto/response/user-nickname-response.dto';
 import { UserProfileResponseDto } from './dto/response/user-profile-response.dto';
 
 @Injectable()
@@ -57,10 +56,10 @@ export class UserService {
     return { message: '이미지 변경 완료되었습니다.' };
   }
 
-  async updateUserNickname(myId: number, nickname: string): Promise<UserNicknameResponseDto> {
+  async updateUserNickname(myId: number, nickname: string): Promise<SuccessResponseDto> {
     await this.checkDuplicatedNickname(nickname);
     await this.userRepository.update({ id: myId }, { nickname: nickname });
-    return { nickname };
+    return { message: '닉네임 변경 완료되었습니다.' };
   }
 
   async getUserProfile(userId: number): Promise<UserProfileResponseDto> {

--- a/types/user/response/index.ts
+++ b/types/user/response/index.ts
@@ -1,4 +1,3 @@
-export { UserHistoryResponse } from './user-history-response.interface';
-export { UserInfoResponse } from './user-info-response.interface';
-export { UserNicknameResponse } from './user-nickname-response.interface';
-export { UserProfileResponse } from './user-profile-response.interface';
+export { UserHistoryResponse } from "./user-history-response.interface";
+export { UserInfoResponse } from "./user-info-response.interface";
+export { UserProfileResponse } from "./user-profile-response.interface";

--- a/types/user/response/user-nickname-response.interface.ts
+++ b/types/user/response/user-nickname-response.interface.ts
@@ -1,3 +1,0 @@
-import { UserNicknameRequest } from '../request/user-nickname-request.interface';
-
-export interface UserNicknameResponse extends UserNicknameRequest {}


### PR DESCRIPTION
## Summary
- nickname 변경 api의 response 수정

## Describe your changes
- nickname response dto 삭제
- `updateUserNickname` return type `Promis<SuccessResponseDto>`로 변경

## Issue number and link
- #306 