### PR TITLE
✨ [Feature] Two factor authentication on Login

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -86,7 +86,7 @@ export class AuthController {
   @SkipUserGuard()
   @HttpCode(HttpStatus.OK)
   @Post('42login/2fa')
-  async verifyTwoFactorAuth(
+  async twoFactorAuthLogin(
     @ExtractUserId() myId: number,
     @Body() { code }: CodeVerificationRequestDto,
     @Res() res: Response,

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -91,8 +91,7 @@ export class AuthController {
     @Body() { code }: CodeVerificationRequestDto,
     @Res() res: Response,
   ): Promise<void> {
-    await this.authService.twoFactorAuthSignIn(myId, code);
-    const token = await this.authService.signIn(myId);
+    const token = await this.authService.twoFactorAuthSignIn(myId, code);
     const clientUrl = this.appConfigService.clientUrl;
     res.redirect(`${clientUrl}/auth?token=${token}`);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -63,15 +63,38 @@ export class AuthController {
       res.cookie('jwt-for-unregistered', token, COOKIE_OPTIONS).redirect(`${clientUrl}/auth/register`);
     } else {
       // REGISTERED -> LOGIN (sign in)
-      const { twoFa } = await this.authService.getTwoFactorAuthEmail(user.id);
+      const { twoFa } = await this.authService.getTwoFactorAuth(user.id);
       if (twoFa !== null) {
-        const token = await this.authService.twoFactorAuth(user.id, twoFa);
+        const token = await this.authService.sendAuthCode(user.id, twoFa);
         res.cookie('jwt-for-2fa', token, COOKIE_OPTIONS).redirect(`${clientUrl}/auth/2fa`);
       } else {
         const token = await this.authService.signIn(user.id);
         res.redirect(`${clientUrl}/auth?token=${token}`);
       }
     }
+  }
+
+  /**
+   * @summary 로그인 2단계 인증
+   * @description POST /auth/42login/2fa
+   */
+  @ApiOperation({ summary: '42 로그인 2단계 인증' })
+  @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
+  @ApiForbiddenResponse({ type: ErrorResponseDto, description: '유효하지 않은 인증 코드' })
+  @ApiBadRequestResponse({ type: ErrorResponseDto, description: '잘못된 인증 코드' })
+  @UseGuards(TwoFaGuard)
+  @SkipUserGuard()
+  @HttpCode(HttpStatus.OK)
+  @Post('42login/2fa')
+  async verifyTwoFactorAuth(
+    @ExtractUserId() myId: number,
+    @Body() { code }: CodeVerificationRequestDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    await this.authService.twoFactorAuthSignIn(myId, code);
+    const token = await this.authService.signIn(myId);
+    const clientUrl = this.appConfigService.clientUrl;
+    res.redirect(`${clientUrl}/auth?token=${token}`);
   }
 
   /**
@@ -83,8 +106,8 @@ export class AuthController {
   @ApiHeaders([{ name: 'x-my-id', description: '내 아이디 (임시값)' }])
   @UseGuards(UserGuard)
   @Get('2fa')
-  getTwoFactorAuthEmail(@ExtractUserId() myId: number): Promise<TwoFactorAuthResponseDto> {
-    return this.authService.getTwoFactorAuthEmail(myId);
+  getTwoFactorAuth(@ExtractUserId() myId: number): Promise<TwoFactorAuthResponseDto> {
+    return this.authService.getTwoFactorAuth(myId);
   }
 
   /**
@@ -120,12 +143,12 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(UserGuard, TwoFaGuard)
   @Post('2fa/verify')
-  async verifyTwoFactorAuth(
+  async updateTwoFactorAuth(
     @ExtractUserId() myId: number,
     @Body() { code }: CodeVerificationRequestDto,
     @Res() res: Response,
   ): Promise<void> {
-    await this.authService.verifyTwoFactorAuth(myId, code);
+    await this.authService.updateTwoFactorAuth(myId, code);
     res.clearCookie('jwt-for-2fa').json({ message: '2단계 인증이 완료되었습니다.' });
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/swagger';
 import { Response } from 'express';
 
-import { COOKIE_EXPIRES_IN } from '../common/constant';
+import { COOKIE_OPTIONS } from '../common/constant';
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { ErrorResponseDto } from '../common/dto/error-response.dto';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
@@ -60,27 +60,13 @@ export class AuthController {
     if (user.id === null) {
       // UNREGSIETERED -> JOIN (sign up)
       const token = await this.authService.signUp(user);
-      res
-        .cookie('jwt-for-unregistered', token, {
-          maxAge: COOKIE_EXPIRES_IN,
-          httpOnly: true,
-          secure: true,
-          sameSite: 'lax',
-        })
-        .redirect(`${clientUrl}/auth/register`);
+      res.cookie('jwt-for-unregistered', token, COOKIE_OPTIONS).redirect(`${clientUrl}/auth/register`);
     } else {
       // REGISTERED -> LOGIN (sign in)
       const { twoFa } = await this.authService.getTwoFactorAuthEmail(user.id);
       if (twoFa !== null) {
         const token = await this.authService.twoFactorAuth(user.id, twoFa);
-        res
-          .cookie('jwt-for-2fa', token, {
-            maxAge: COOKIE_EXPIRES_IN,
-            httpOnly: true,
-            secure: true,
-            sameSite: 'lax',
-          })
-          .redirect(`${clientUrl}/auth/2fa`);
+        res.cookie('jwt-for-2fa', token, COOKIE_OPTIONS).redirect(`${clientUrl}/auth/2fa`);
       } else {
         const token = await this.authService.signIn(user.id);
         res.redirect(`${clientUrl}/auth?token=${token}`);
@@ -118,14 +104,7 @@ export class AuthController {
     @Res() res: Response,
   ): Promise<void> {
     const token = await this.authService.twoFactorAuth(myId, email);
-    res
-      .cookie('jwt-for-2fa', token, {
-        maxAge: COOKIE_EXPIRES_IN,
-        httpOnly: true,
-        secure: true,
-        sameSite: 'lax',
-      })
-      .json({ message: '2단계 인증 이메일이 전송되었습니다.' });
+    res.cookie('jwt-for-2fa', token, COOKIE_OPTIONS).json({ message: '2단계 인증 이메일이 전송되었습니다.' });
   }
 
   /**

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -72,8 +72,15 @@ export class AuthController {
       // REGISTERED -> LOGIN (sign in)
       const { twoFa } = await this.authService.getTwoFactorAuthEmail(user.id);
       if (twoFa !== null) {
-        await this.authService.twoFactorAuth(user.id, twoFa);
-        res.redirect(`${clientUrl}/auth/2fa`);
+        const token = await this.authService.twoFactorAuth(user.id, twoFa);
+        res
+          .cookie('jwt-for-2fa', token, {
+            maxAge: COOKIE_EXPIRES_IN,
+            httpOnly: true,
+            secure: true,
+            sameSite: 'lax',
+          })
+          .redirect(`${clientUrl}/auth/2fa`);
       } else {
         const token = await this.authService.signIn(user.id);
         res.redirect(`${clientUrl}/auth?token=${token}`);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -70,8 +70,14 @@ export class AuthController {
         .redirect(`${clientUrl}/auth/register`);
     } else {
       // REGISTERED -> LOGIN (sign in)
-      const token = await this.authService.signIn(user.id);
-      res.redirect(`${clientUrl}/auth?token=${token}`);
+      const { twoFa } = await this.authService.getTwoFactorAuthEmail(user.id);
+      if (twoFa !== null) {
+        await this.authService.twoFactorAuth(user.id, twoFa);
+        res.redirect(`${clientUrl}/auth/2fa`);
+      } else {
+        const token = await this.authService.signIn(user.id);
+        res.redirect(`${clientUrl}/auth?token=${token}`);
+      }
     }
   }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -55,12 +55,13 @@ export class AuthService {
     return this.jwtService.sign(payload, signOptions);
   }
 
-  async twoFactorAuthSignIn(myId: number, code: string): Promise<void> {
+  async twoFactorAuthSignIn(myId: number, code: string): Promise<string> {
     const value: TwoFactorAuth | undefined = await this.cacheManager.get(`${myId}`);
     if (value === undefined) {
       throw new ForbiddenException('유효하지 않은 인증 코드입니다.');
     }
     await this.verifyTwoFactorAuth(myId, code, value.code);
+    return this.signIn(myId);
   }
 
   async getTwoFactorAuth(myId: number): Promise<TwoFactorAuthResponseDto> {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -26,7 +26,6 @@ export class AuthService {
     private readonly mailerService: MailerService,
   ) {}
 
-  // UNREGISTERD -> SIGN UP (Register)
   async signUp(user: LoginInfo): Promise<string> {
     const auth = await this.authRepository.findOneBy({ email: user.email });
 
@@ -43,7 +42,6 @@ export class AuthService {
     return this.jwtService.sign(payload, signOptions);
   }
 
-  // REGISTERD -> SIGN IN (Login)
   async signIn(userId: number): Promise<string> {
     // CHECK 필요 없을 거 같음 (무조건 user table에 있는 경우에 signIn이 실행됨)
     // if ((await this.userRepository.findOneBy({ id: userId })) === null) {
@@ -57,13 +55,39 @@ export class AuthService {
     return this.jwtService.sign(payload, signOptions);
   }
 
-  async getTwoFactorAuthEmail(myId: number): Promise<TwoFactorAuthResponseDto> {
+  async twoFactorAuthSignIn(myId: number, code: string): Promise<void> {
+    const value: TwoFactorAuth | undefined = await this.cacheManager.get(`${myId}`);
+    if (value === undefined) {
+      throw new ForbiddenException('유효하지 않은 인증 코드입니다.');
+    }
+    await this.verifyTwoFactorAuth(myId, code, value.code);
+  }
+
+  async getTwoFactorAuth(myId: number): Promise<TwoFactorAuthResponseDto> {
     const auth = await this.authRepository.findOne({ where: { id: myId }, select: ['twoFa'] });
 
     if (auth === null) {
       return { twoFa: null };
     }
     return { twoFa: auth.twoFa };
+  }
+
+  async sendAuthCode(myId: number, email: string): Promise<string> {
+    const code = String(Math.floor(Math.random() * 1000000)).padStart(6, '0');
+
+    await this.mailerService.sendMail({
+      to: email,
+      subject: 'GhostPhong 인증번호입니다 ✔',
+      html: this.getEmailTemplate(code),
+    });
+    await this.cacheManager.set(`${myId}`, { email, code }, TWO_FA_EXPIRES_IN);
+
+    const payload = { userId: myId };
+    const signOptions = {
+      secret: this.jwtConfigService.twoFaSecretKey,
+      expiresIn: TWO_FA_EXPIRES_IN,
+    };
+    return this.jwtService.sign(payload, signOptions);
   }
 
   async twoFactorAuth(myId: number, email: string): Promise<string> {
@@ -74,44 +98,23 @@ export class AuthService {
     if ((await this.authRepository.findOneBy({ twoFa: email })) !== null) {
       throw new ConflictException('이미 인증이 완료된 이메일입니다.');
     }
-    const code = String(Math.floor(Math.random() * 1000000)).padStart(6, '0');
-
-    await this.mailerService.sendMail({
-      to: email,
-      subject: 'GhostPhong 인증번호입니다 ✔',
-      html: this.getEmailTemplate(code),
-    });
-
-    await this.cacheManager.set(`${myId}`, { email, code }, TWO_FA_EXPIRES_IN);
-    // token
-
-    const payload = { userId: myId };
-    const signOptions = {
-      secret: this.jwtConfigService.twoFaSecretKey,
-      expiresIn: TWO_FA_EXPIRES_IN,
-    };
-    return this.jwtService.sign(payload, signOptions);
+    return this.sendAuthCode(myId, email);
   }
 
-  async verifyTwoFactorAuth(myId: number, code: string): Promise<void> {
+  async updateTwoFactorAuth(myId: number, code: string): Promise<void> {
     const auth = await this.authRepository.findOne({ where: { id: myId }, select: ['twoFa'] });
     if (auth !== null) {
       throw new ConflictException('이미 2단계 인증이 완료된 유저입니다.');
     }
-
     const value: TwoFactorAuth | undefined = await this.cacheManager.get(`${myId}`);
     if (value === undefined) {
       throw new ForbiddenException('유효하지 않은 인증 코드입니다.');
     }
     if ((await this.authRepository.findOneBy({ email: value.email })) !== null) {
-      throw new ConflictException('이미 2단계 인증이 완료된 이메일입니다.');
+      throw new ConflictException('이미 사용중인 이메일입니다.');
     }
-    if (value.code !== code) {
-      throw new BadRequestException('잘못된 인증 코드입니다.');
-    }
-
+    await this.verifyTwoFactorAuth(myId, code, value.code);
     await this.authRepository.update({ id: myId }, { twoFa: value.email });
-    await this.cacheManager.del(`${myId}`);
   }
 
   async deleteTwoFactorAuth(myId: number): Promise<SuccessResponseDto> {
@@ -124,6 +127,13 @@ export class AuthService {
   }
 
   // SECTION private
+  private async verifyTwoFactorAuth(myId: number, code: string, successCode: string) {
+    if (code !== successCode) {
+      throw new BadRequestException('잘못된 인증 코드입니다.');
+    }
+    await this.cacheManager.del(`${myId}`);
+  }
+
   private getEmailTemplate(code: string): string {
     return `
     <!DOCTYPE html>

--- a/backend/src/auth/guard/two-fa.guard.ts
+++ b/backend/src/auth/guard/two-fa.guard.ts
@@ -30,7 +30,8 @@ export class TwoFaGuard implements CanActivate {
     const request: Request = context.switchToHttp().getRequest<Request>();
     const token = request.cookies['jwt-for-2fa'];
     try {
-      this.jwtService.verify(token, { secret: this.jwtConfigService.twoFaSecretKey });
+      const { userId } = this.jwtService.verify(token, { secret: this.jwtConfigService.twoFaSecretKey });
+      request.user = { userId: userId };
       return true;
     } catch {
       throw new UnauthorizedException('2FA 토큰 검증에 실패했습니다.');

--- a/backend/src/common/constant.ts
+++ b/backend/src/common/constant.ts
@@ -2,6 +2,8 @@
  * @description: 상수 저장 파일
  */
 
+import { CookieOptions } from 'express';
+
 const FRIEND_LIMIT = 42;
 const BLOCKED_USER_LIMIT = 42;
 const DEFAULT_IMAGE = 'images/default_image.png';
@@ -15,6 +17,13 @@ const TWO_FA_EXPIRES_IN = 1000 * 60 * 5; // 5m
 const TWO_FA_MAX = 1000;
 const COOKIE_EXPIRES_IN = 1000 * 60 * 15; // 15m
 
+const COOKIE_OPTIONS: CookieOptions = {
+  maxAge: COOKIE_EXPIRES_IN,
+  httpOnly: true,
+  secure: true,
+  sameSite: 'lax',
+};
+
 export {
   FRIEND_LIMIT,
   BLOCKED_USER_LIMIT,
@@ -27,5 +36,5 @@ export {
   TWO_FA_JWT_EXPIRES_IN,
   TWO_FA_EXPIRES_IN,
   TWO_FA_MAX,
-  COOKIE_EXPIRES_IN,
+  COOKIE_OPTIONS,
 };


### PR DESCRIPTION
## Summary
- 2fa 설정한 유저에 대한 로그인 로직 추가

## Describe your changes
### 로직
- 2fa 검증이 '초기 설정', '로그인' 두 가지 경우에서 발생하는데 로직이 다릅니다!
- 두 로직 모두 내부적으로 `verifyTwoFactorAuth` private 함수 호출하여 2fa 인증코드를 검증
- **'2fa 초기 설정'** 과정에서 code 검증 : `auth` table의 `two_fa` column 업데이트
  - `POST /auth/2fa/verify` -> `updateTwoFactorAuth`
- **'2fa 로그인'** 과정에서 code 검증 : `user` access token 발급 후 `${clientUrl}/auth?token=`으로 redirect
  - `POST /auth/42login/2fa` -> `TwoFactorAuthSignIn`

### 변경 사항
- 2fa 인증번호 생성 및 이메일 전송하는 함수 분리 : `sendAuthCode`
- 2fa 인증번호 검증하는 private 함수 분리 : `verifyTwoFactorAuth`

### 추가
- `GET /auth/42login/callback`
  - 2fa 이메일 존재할 경우 `sendAuthCode`로 인증번호 이메일 전송 -> 'jwt-for-2fa' token cookie 설정
- `POST /auth/42login/2fa`
  - 로그인 2단계 인증 검증 및 user token 발급 후 redirect

## Issue number and link
- #231 