### PR TITLE
🔨 [Refactor] Connection module for websocket connections

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { ChannelModule } from './channel/channel.module';
 import { AppConfigModule } from './config/app/configuration.module';
 import { DatabaseConfigModule } from './config/database/configuration.module';
 import { DatabaseConfigService } from './config/database/configuration.service';
+import { ConnectionModule } from './connection/connection.module';
 import { FriendModule } from './friend/friend.module';
 import { MessageModule } from './message/message.module';
 import { UserModule } from './user/user.module';
@@ -37,6 +38,7 @@ import { UserModule } from './user/user.module';
     FriendModule,
     MessageModule,
     ChannelModule,
+    ConnectionModule,
   ],
   controllers: [AppController],
   providers: [AppService, { provide: APP_GUARD, useClass: UserGuard }],

--- a/backend/src/connection/connection.gateway.spec.ts
+++ b/backend/src/connection/connection.gateway.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UserGateway } from './user.gateway';
+``;
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Friendship } from '../entity/friendship.entity';
 import { Repository } from 'typeorm';
@@ -8,9 +8,10 @@ import { UserStatusRepository } from '../repository/user-status.repository';
 import { JwtService } from '@nestjs/jwt';
 import { AppConfigService } from '../config/app/configuration.service';
 import { Server, Socket } from 'socket.io';
+import { ConnectionGateway } from './connection.gateway';
 
-describe('UserGateway', () => {
-  let gateway: UserGateway;
+describe('ConnectionGateway', () => {
+  let gateway: ConnectionGateway;
   let server: Server;
   let socket: Socket;
   let friendshipRepository: Repository<Friendship>;
@@ -22,7 +23,7 @@ describe('UserGateway', () => {
   beforeAll(async () => {
     const moduleRef: TestingModule = await Test.createTestingModule({
       providers: [
-        UserGateway,
+        ConnectionGateway,
         {
           provide: getRepositoryToken(Friendship),
           useClass: Repository,
@@ -44,7 +45,7 @@ describe('UserGateway', () => {
       ],
     }).compile();
 
-    gateway = moduleRef.get<UserGateway>(UserGateway);
+    gateway = moduleRef.get<ConnectionGateway>(ConnectionGateway);
     server = gateway.server;
     friendshipRepository = moduleRef.get<Repository<Friendship>>(getRepositoryToken(Friendship));
     socketIdRepository = moduleRef.get<SocketIdRepository>(SocketIdRepository);
@@ -70,6 +71,9 @@ describe('UserGateway', () => {
       },
       to: jest.fn().mockReturnThis(),
       emit: jest.fn(),
+      in: jest.fn().mockReturnThis(),
+      socketsJoin: jest.fn(),
+      socketsLeave: jest.fn(),
     } as any;
 
     jest.spyOn(gateway as any, 'findFriendList').mockImplementation(() => [
@@ -96,11 +100,10 @@ describe('UserGateway', () => {
 
     it('user status repository 에 친구가 있으면 room 에 3명이 join 되어야 한다.', () => {
       gateway.handleConnection(socket);
-      // friendSocket join 3번, socket join 3번
-      expect(socket.join).toBeCalledTimes(6);
-      expect(socket.join).toBeCalledWith('user-1');
+      expect(socket.join).toBeCalledTimes(3);
       expect(socket.join).toBeCalledWith('user-2');
       expect(socket.join).toBeCalledWith('user-3');
+      expect(socket.join).toBeCalledWith('user-4');
     });
   });
 

--- a/backend/src/connection/connection.gateway.spec.ts
+++ b/backend/src/connection/connection.gateway.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-``;
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Friendship } from '../entity/friendship.entity';
 import { Repository } from 'typeorm';

--- a/backend/src/connection/connection.gateway.ts
+++ b/backend/src/connection/connection.gateway.ts
@@ -18,7 +18,7 @@ import { SocketIdRepository } from '../repository/socket-id.repository';
 import { UserStatusRepository } from '../repository/user-status.repository';
 
 @WebSocketGateway({ cors: corsOption })
-export class UserGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   public server: Server;
 

--- a/backend/src/connection/connection.gateway.ts
+++ b/backend/src/connection/connection.gateway.ts
@@ -13,7 +13,9 @@ import { Repository } from 'typeorm';
 import { corsOption } from '../common/option/cors.option';
 import { AppConfigService } from '../config/app/configuration.service';
 import { Friendship } from '../entity/friendship.entity';
+import { ChannelRepository } from '../repository/channel.repository';
 import { Status } from '../repository/model/user-status';
+import { PrivateChannelRepository } from '../repository/private-channel.repository';
 import { SocketIdRepository } from '../repository/socket-id.repository';
 import { UserStatusRepository } from '../repository/user-status.repository';
 
@@ -27,6 +29,8 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
     private readonly friendshipRepository: Repository<Friendship>,
     private readonly socketIdRepository: SocketIdRepository,
     private readonly userStatusRepository: UserStatusRepository,
+    private readonly channelRepository: ChannelRepository,
+    private readonly privateChannelRepository: PrivateChannelRepository,
     private readonly jwtService: JwtService,
     private readonly appConfigService: AppConfigService,
   ) {}
@@ -52,10 +56,13 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
 
   handleDisconnect(@ConnectedSocket() socket: Socket): void {
     const userId: number = socket.data.userId;
+    this.leaveChannel(userId);
+
     this.userStatusRepository.delete(userId);
-    this.socketIdRepository.delete(socket.data.userId);
+    this.socketIdRepository.delete(userId);
+
     this.emitUserStatusToFriends(userId, 'offline');
-    this.server.socketsLeave(`user-${userId}`);
+    this.server.socketsLeave(`user-${userId}`); // 'user-${userId}' room 의 모든 socket 을 leave 시킨다
 
     console.log('WebSocketServer Disconnect');
     console.log(userId, 'is disconnected');
@@ -116,6 +123,21 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
           socket.join(`user-${friendId}`); //join my socket to friend's room
           this.server.in(socketId).socketsJoin(userRoom); // join friend's socket to my room
         }
+      }
+    });
+  }
+
+  /**
+   * channel 에 들어가 있는 상태라면 channel의 users 에서 user 를 제거한다.
+   *
+   * @param userId
+   */
+  private leaveChannel(userId: number): void {
+    const channels = [...this.channelRepository.findAll(), ...this.privateChannelRepository.findAll()];
+
+    channels.forEach((channel) => {
+      if (channel.users.has(userId)) {
+        return channel.users.delete(userId);
       }
     });
   }

--- a/backend/src/connection/connection.module.ts
+++ b/backend/src/connection/connection.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AppConfigModule } from '../config/app/configuration.module';
+import { Friendship } from '../entity/friendship.entity';
+import { RepositoryModule } from '../repository/repository.module';
+
+import { ConnectionGateway } from './connection.gateway';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Friendship]), RepositoryModule, AppConfigModule, JwtModule.register({})],
+  providers: [ConnectionGateway],
+  exports: [ConnectionGateway],
+})
+export class ConnectionModule {}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,30 +1,24 @@
 import { Module, forwardRef } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '../auth/auth.module';
 import { AppConfigModule } from '../config/app/configuration.module';
 import { Achievement } from '../entity/achievement.entity';
-import { Friendship } from '../entity/friendship.entity';
 import { GameHistory } from '../entity/game-history.entity';
 import { UserRecord } from '../entity/user-record.entity';
 import { User } from '../entity/user.entity';
-import { RepositoryModule } from '../repository/repository.module';
 
 import { UserController } from './user.controller';
-import { UserGateway } from './user.gateway';
 import { UserService } from './user.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Achievement, UserRecord, GameHistory, Friendship]),
+    TypeOrmModule.forFeature([User, Achievement, UserRecord, GameHistory]),
     forwardRef(() => AuthModule),
     AppConfigModule,
-    RepositoryModule,
-    JwtModule.register({}),
   ],
   controllers: [UserController],
-  providers: [UserService, UserGateway],
+  providers: [UserService],
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
## Summary
- websocket 의 `handleConnection`, `handleDisconnect` 이벤트를 관리하는 `ConnectionGateway` 구현
- connection gateway 만 분리하여 관리하기 위해 `ConnectionModule` 구현
## Describe your changes
- `UserGateway` -> `ConnectionGateway` 로 모두 옮겨지고 `UserModule` 의 필요없어진 import 들을 삭제했습니다.
- socket 처리 부분이 변경되어 테스트의 mocking 부분에 변경 반영했습니다.
- socket disconnect 되었을 때 room 을 나가는 logic 도 추가했습니다.  추후 `leave-channel` 이벤트에서도 사용할 수 있도록 `leaveChannel` 함수로 분리했습니다.
## Issue number and link
- close #316 
- close #319 