### PR TITLE
✨ [Feature] Game server side engine and events

### DIFF
--- a/backend/src/channel/dto/socket/chat.dto.ts
+++ b/backend/src/channel/dto/socket/chat.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsNotEmpty, IsNumber, IsString, Max, MaxLength, Min } from 'class-validator';
+import { IsDateString, IsInt, IsNotEmpty, IsString, Max, MaxLength, Min } from 'class-validator';
 
 import { Chat } from '@/types/channel/socket';
 
@@ -15,7 +15,7 @@ export default class ChatDto implements Chat {
    * @example 4
    */
   @IsNotEmpty()
-  @IsNumber()
+  @IsInt()
   @Min(1)
   @Max(2147483647)
   senderId: number;

--- a/backend/src/entity/game-history.entity.ts
+++ b/backend/src/entity/game-history.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { User } from './user.entity';
 
@@ -7,10 +7,18 @@ export class GameHistory {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column()
+  winnerId: number;
+
+  @Column()
+  loserId: number;
+
   @ManyToOne(() => User)
+  @JoinColumn()
   winner: User;
 
   @ManyToOne(() => User)
+  @JoinColumn()
   loser: User;
 
   @Column()

--- a/backend/src/game/dto/game-start.dto.ts
+++ b/backend/src/game/dto/game-start.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, Length } from 'class-validator';
+
+import { GameStart } from '@/types/game';
+
+export class GameStartDto implements GameStart {
+  @IsString()
+  @Length(21, 21)
+  gameId: string;
+}

--- a/backend/src/game/dto/move-bar.dto.ts
+++ b/backend/src/game/dto/move-bar.dto.ts
@@ -1,0 +1,16 @@
+import { IsNumber, IsString, Length, Max, Min } from 'class-validator';
+
+import { MoveBar } from '@/types/game';
+
+import { CANVASE_HEIGHT } from '@/game/game-data';
+
+export class MoveBarDto implements MoveBar {
+  @IsString()
+  @Length(21, 21)
+  gameId: string;
+
+  @IsNumber()
+  @Max(CANVASE_HEIGHT)
+  @Min(0)
+  y: number;
+}

--- a/backend/src/game/dto/request/create-game-request.dto.ts
+++ b/backend/src/game/dto/request/create-game-request.dto.ts
@@ -1,9 +1,0 @@
-import { IsString, Length } from 'class-validator';
-
-import { CreateGameRequest } from '@/types/game';
-
-export class CreateGameRequestDto implements CreateGameRequest {
-  @IsString()
-  @Length(21, 21)
-  channelId: string;
-}

--- a/backend/src/game/game-engine.service.ts
+++ b/backend/src/game/game-engine.service.ts
@@ -30,7 +30,7 @@ export class GameEngineService {
 
   logger: Logger = new Logger('GameEngine');
 
-  startGame(game: Game) {
+  startGame(game: Game): void {
     game.syncIntervalId = setInterval(() => {
       this.gameGateway.broadcastGameData(game.gameData);
     }, SYNC_INTERVAL);
@@ -39,7 +39,7 @@ export class GameEngineService {
     }, ENGINE_INTERVAL);
   }
 
-  async endGame(game: Game) {
+  async endGame(game: Game): Promise<void> {
     if (game.engineIntervalId !== undefined) {
       // end loops
       clearInterval(game.engineIntervalId);
@@ -81,7 +81,7 @@ export class GameEngineService {
     });
   }
 
-  private async gameLoop(game: Game) {
+  private async gameLoop(game: Game): Promise<void> {
     const { gameData } = game;
     updateBall(gameData);
 

--- a/backend/src/game/game-engine.service.ts
+++ b/backend/src/game/game-engine.service.ts
@@ -18,7 +18,7 @@ const ENGINE_INTERVAL = 10;
 const SYNC_INTERVAL = 500;
 
 @Injectable()
-export class GameEngine {
+export class GameEngineService {
   constructor(
     private readonly gameRepository: GameRepository,
     private readonly channelRepository: ChannelRepository,

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -4,7 +4,7 @@ import { ApiConflictResponse, ApiForbiddenResponse, ApiOperation } from '@nestjs
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 
-import { CreateGameRequestDto } from './dto/request/create-game-request.dto';
+import { GameStartDto } from './dto/game-start.dto';
 import { GameService } from './game.service';
 
 @Controller('game')
@@ -16,7 +16,7 @@ export class GameController {
   @ApiConflictResponse({ description: '해당 채널에서 이미 진행 중인 게임이 있는 경우' })
   @HttpCode(HttpStatus.OK)
   @Post()
-  createGame(@ExtractUserId() userId: number, @Body() { channelId }: CreateGameRequestDto): SuccessResponseDto {
-    return this.gameService.createGame(channelId, userId);
+  createGame(@ExtractUserId() userId: number, @Body() { gameId }: GameStartDto): SuccessResponseDto {
+    return this.gameService.createGame(gameId, userId);
   }
 }

--- a/backend/src/game/game.engine.ts
+++ b/backend/src/game/game.engine.ts
@@ -1,10 +1,14 @@
-import { Injectable, Inject, forwardRef } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Injectable, Inject, forwardRef, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 
 import { checkPlayerCollision, checkWallcollision, checkGameEnded, updateBall } from '@/game/utils';
 
+import { GameData } from '../../../game/game-data';
 import { GameHistory } from '../entity/game-history.entity';
+import { UserRecord } from '../entity/user-record.entity';
+import { User } from '../entity/user.entity';
+import { ChannelRepository } from '../repository/channel.repository';
 import { GameRepository } from '../repository/game.repository';
 import { Game } from '../repository/model/game';
 
@@ -17,11 +21,14 @@ const SYNC_INTERVAL = 500;
 export class GameEngine {
   constructor(
     private readonly gameRepository: GameRepository,
+    private readonly channelRepository: ChannelRepository,
     @Inject(forwardRef(() => GameGateway))
     private readonly gameGateway: GameGateway,
-    @InjectRepository(GameHistory)
-    private readonly gameHistoryRepository: Repository<GameHistory>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
+
+  logger: Logger = new Logger('GameEngine');
 
   startGame(game: Game) {
     game.syncIntervalId = setInterval(() => {
@@ -32,14 +39,43 @@ export class GameEngine {
     }, ENGINE_INTERVAL);
   }
 
-  endGame(game: Game) {
+  async endGame(game: Game) {
     if (game.engineIntervalId !== undefined) {
       // end loops
       clearInterval(game.engineIntervalId);
+      game.engineIntervalId = undefined;
       clearInterval(game.syncIntervalId);
+      game.syncIntervalId = undefined;
     }
-    // update user data
-    this.gameRepository.delete(game.gameData.id);
+    const { gameData } = game;
+    this.gameGateway.updateUserStatus(gameData.leftPlayer.userId, 'online');
+    this.gameGateway.updateUserStatus(gameData.rightPlayer.userId, 'online');
+    this.channelRepository.update(gameData.id, { isInGame: false });
+    this.gameRepository.delete(gameData.id);
+    try {
+      await this.insertGameHistory(gameData);
+    } catch (e) {
+      this.logger.error(e);
+    }
+  }
+
+  private insertGameHistory(gameData: GameData): Promise<void> {
+    const winner = gameData.leftPlayer.score > gameData.rightPlayer.score ? gameData.leftPlayer : gameData.rightPlayer;
+    const loser = winner === gameData.leftPlayer ? gameData.rightPlayer : gameData.leftPlayer;
+    const point = winner.score - loser.score;
+
+    return this.dataSource.manager.transaction(async (manager) => {
+      await manager.insert(GameHistory, {
+        winnerId: winner.userId,
+        loserId: loser.userId,
+        winnerScore: winner.score,
+        loserScore: loser.score,
+      });
+      await manager.update(User, { id: winner.userId }, { exp: () => `exp + ${point}` });
+      await manager.update(User, { id: loser.userId }, { exp: () => `exp - ${point}` });
+      await manager.update(UserRecord, { id: winner.userId }, { winCount: () => `winCount + 1` });
+      await manager.update(UserRecord, { id: loser.userId }, { loseCount: () => `loseCount + 1` });
+    });
   }
 
   private gameLoop(game: Game) {

--- a/backend/src/game/game.engine.ts
+++ b/backend/src/game/game.engine.ts
@@ -3,7 +3,7 @@ import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 
 import { Player } from '@/game/game-data';
-import { checkPlayerCollision, checkWallcollision, checkGameEnded, updateBall } from '@/game/utils';
+import { checkPlayerCollision, checkWallCollision, checkGameEnded, updateBall } from '@/game/utils';
 
 import { GameHistory } from '../entity/game-history.entity';
 import { UserRecord } from '../entity/user-record.entity';
@@ -88,7 +88,7 @@ export class GameEngine {
     if (checkPlayerCollision(gameData) === true) {
       this.gameGateway.broadcastGameData(gameData);
     }
-    checkWallcollision(gameData.ball);
+    checkWallCollision(gameData.ball);
     if (checkGameEnded(gameData) === true) {
       this.gameGateway.broadcastGameData(gameData);
       if (gameData.rightPlayer.score === 10 || gameData.leftPlayer.score === 10) {

--- a/backend/src/game/game.engine.ts
+++ b/backend/src/game/game.engine.ts
@@ -1,0 +1,41 @@
+import { GameData } from '@/game/game-data';
+import { checkPlayerCollision, checkWallcollision, checkGameEnded, updateBall } from '@/game/utils';
+
+import { GameRepository } from '../repository/game.repository';
+import { Game } from '../repository/model/game';
+
+import { GameGateway } from './game.gateway';
+
+export class GameEngine {
+  constructor(private readonly gameRepository: GameRepository, private readonly gameGateway: GameGateway) {}
+
+  startGame(game: Game) {
+    game.intervalId = setInterval(() => {
+      this.gameLoop(game.gameData);
+    }, 1000);
+  }
+
+  endGame(game: Game) {
+    if (game.intervalId !== undefined) {
+      clearInterval(game.intervalId);
+    }
+    // update user data
+    this.gameRepository.delete(game.gameData.id);
+  }
+
+  private gameLoop(gameData: GameData) {
+    updateBall(gameData);
+    if (checkPlayerCollision(gameData) === true) {
+      //emit game data
+    }
+    checkWallcollision(gameData.ball);
+    if (checkGameEnded(gameData) === true) {
+      //emit game data
+      if (gameData.rightPlayer.score === 10) {
+        //emit game end
+      } else if (gameData.leftPlayer.score === 10) {
+        //emit game end
+      }
+    }
+  }
+}

--- a/backend/src/game/game.engine.ts
+++ b/backend/src/game/game.engine.ts
@@ -1,3 +1,5 @@
+import { Injectable, Inject, forwardRef } from '@nestjs/common';
+
 import { GameData } from '@/game/game-data';
 import { checkPlayerCollision, checkWallcollision, checkGameEnded, updateBall } from '@/game/utils';
 
@@ -6,18 +8,30 @@ import { Game } from '../repository/model/game';
 
 import { GameGateway } from './game.gateway';
 
+const ENGINE_INTERVAL = 10;
+const SYNC_INTERVAL = 500;
+
+@Injectable()
 export class GameEngine {
-  constructor(private readonly gameRepository: GameRepository, private readonly gameGateway: GameGateway) {}
+  constructor(
+    private readonly gameRepository: GameRepository,
+    @Inject(forwardRef(() => GameGateway))
+    private readonly gameGateway: GameGateway,
+  ) {}
 
   startGame(game: Game) {
-    game.intervalId = setInterval(() => {
+    game.engineIntervalId = setInterval(() => {
       this.gameLoop(game.gameData);
-    }, 1000);
+    }, ENGINE_INTERVAL);
+
+    game.syncIntervalId = setInterval(() => {
+      //this.gameGateway.emitGameData(game.gameData);
+    }, SYNC_INTERVAL);
   }
 
   endGame(game: Game) {
-    if (game.intervalId !== undefined) {
-      clearInterval(game.intervalId);
+    if (game.engineIntervalId !== undefined) {
+      clearInterval(game.engineIntervalId);
     }
     // update user data
     this.gameRepository.delete(game.gameData.id);

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -1,12 +1,47 @@
-import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
-import { Server } from 'socket.io';
+import { UsePipes, ValidationPipe } from '@nestjs/common';
+import {
+  ConnectedSocket,
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+  WsException,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
 
 import { corsOption } from '../common/option/cors.option';
+import { createWsException } from '../common/util';
+import { GameRepository } from '../repository/game.repository';
+
+import { GameStartDto } from './dto/game-start.dto';
 
 @WebSocketGateway({ cors: corsOption })
 export class GameGateway {
   @WebSocketServer()
   public server: Server;
+
+  constructor(private readonly gameRepository: GameRepository) {}
+
+  @UsePipes(new ValidationPipe({ exceptionFactory: createWsException }))
+  @SubscribeMessage('game-start')
+  public handleGameStart(@ConnectedSocket() socket: Socket, @MessageBody() { gameId }: GameStartDto) {
+    const game = this.gameRepository.find(gameId);
+    if (!game) {
+      throw new WsException('게임이 존재하지 않습니다.');
+    }
+    const userId: number = socket.data.userId;
+    if (game.gameData.leftPlayer.userId === userId) {
+      game.playerStarted[0] = true;
+    } else if (game.gameData.rightPlayer.userId === userId) {
+      game.playerStarted[1] = true;
+    } else {
+      throw new WsException('게임에 참여하지 않은 유저입니다.');
+    }
+    if (game.playerStarted[0] && game.playerStarted[1]) {
+      // start game engine
+      // game data broadcast
+    }
+  }
 
   broadcastGameStart(gameId: string) {
     this.server.to(gameId).emit('game-start', { gameId });

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -14,6 +14,7 @@ import { GameData, Player } from '@/game/game-data';
 import { corsOption } from '../common/option/cors.option';
 import { createWsException } from '../common/util';
 import { GameRepository } from '../repository/game.repository';
+import { Status } from '../repository/model/user-status';
 import { UserStatusRepository } from '../repository/user-status.repository';
 
 import { GameStartDto } from './dto/game-start.dto';
@@ -83,8 +84,8 @@ export class GameGateway {
     });
   }
 
-  updateUserStatus(userId: number, status: string) {
-    this.userStatusRepository.update(userId, { status: 'game' });
+  updateUserStatus(userId: number, status: Status) {
+    this.userStatusRepository.update(userId, { status });
     this.server.to(`user-${userId}`).emit('user-status', { id: userId, status });
   }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
+import { GameData } from '../../../game/game-data';
 import { corsOption } from '../common/option/cors.option';
 import { createWsException } from '../common/util';
 import { GameRepository } from '../repository/game.repository';
@@ -54,6 +55,10 @@ export class GameGateway {
     }
   }
 
+  broadcastGameData(gamedata: GameData) {
+    this.server.to(gamedata.id).emit('game-data', gamedata);
+  }
+
   /**
    * channel 에 있는 유저들에게 게임이 시작함을 알린다.
    *
@@ -70,9 +75,5 @@ export class GameGateway {
    */
   emitGameStatusToFriends(userId: number) {
     this.server.to(`user-${userId}`).emit('user-status', { id: userId, status: 'game' });
-  }
-
-  emitExceptionToGame(gameId: string, message: string) {
-    this.server.to(gameId).emit('exception', { status: 'error', message });
   }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -43,7 +43,21 @@ export class GameGateway {
     }
   }
 
+  /**
+   * channel 에 있는 유저들에게 게임이 시작함을 알린다.
+   *
+   * @param gameId
+   */
   broadcastGameStart(gameId: string) {
     this.server.to(gameId).emit('game-start', { gameId });
+  }
+
+  /**
+   * user의 친구들에게 게임 중 상태임을 알린다.
+   *
+   * @param userId
+   */
+  emitGameStatusToFriends(userId: number) {
+    this.server.to(`user-${userId}`).emit('user-status', { id: userId, status: 'game' });
   }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -9,6 +9,6 @@ export class GameGateway {
   public server: Server;
 
   broadcastGameStart(gameId: string) {
-    this.server.to(gameId).emit('game-start');
+    this.server.to(gameId).emit('game-start', { gameId });
   }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -18,7 +18,7 @@ import { Status } from '../repository/model/user-status';
 import { UserStatusRepository } from '../repository/user-status.repository';
 
 import { GameStartDto } from './dto/game-start.dto';
-import { GameEngine } from './game.engine';
+import { GameEngineService } from './game-engine.service';
 
 @UsePipes(
   new ValidationPipe({
@@ -33,8 +33,8 @@ export class GameGateway {
   constructor(
     private readonly gameRepository: GameRepository,
     private readonly userStatusRepository: UserStatusRepository,
-    @Inject(forwardRef(() => GameEngine))
-    private readonly gameEngine: GameEngine,
+    @Inject(forwardRef(() => GameEngineService))
+    private readonly gameEngine: GameEngineService,
   ) {}
 
   @SubscribeMessage('game-start')

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -1,4 +1,4 @@
-import { UsePipes, ValidationPipe } from '@nestjs/common';
+import { Inject, forwardRef, UsePipes, ValidationPipe } from '@nestjs/common';
 import {
   ConnectedSocket,
   MessageBody,
@@ -21,7 +21,11 @@ export class GameGateway {
   @WebSocketServer()
   public server: Server;
 
-  constructor(private readonly gameRepository: GameRepository, private readonly gameEngine: GameEngine) {}
+  constructor(
+    private readonly gameRepository: GameRepository,
+    @Inject(forwardRef(() => GameEngine))
+    private readonly gameEngine: GameEngine,
+  ) {}
 
   @UsePipes(new ValidationPipe({ exceptionFactory: createWsException }))
   @SubscribeMessage('game-start')
@@ -43,7 +47,7 @@ export class GameGateway {
       if (game === undefined) {
         return undefined;
       }
-      if (game.intervalId !== undefined) {
+      if (game.engineIntervalId !== undefined) {
         throw new WsException('이미 게임이 시작되었습니다.');
       }
       this.gameEngine.startGame(game);

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -39,7 +39,7 @@ export class GameGateway {
   ) {}
 
   @SubscribeMessage('game-start')
-  handleGameStart(@ConnectedSocket() socket: Socket, @MessageBody() { gameId }: GameStartDto) {
+  handleGameStart(@ConnectedSocket() socket: Socket, @MessageBody() { gameId }: GameStartDto): void {
     const game = this.gameRepository.find(gameId);
     if (game === undefined) {
       throw new WsException('게임이 존재하지 않습니다.');
@@ -53,10 +53,6 @@ export class GameGateway {
       throw new WsException('게임의 플레이어가 아닙니다.');
     }
     if (game.playerStarted[0] && game.playerStarted[1]) {
-      const game = this.gameRepository.find(gameId);
-      if (game === undefined) {
-        return undefined;
-      }
       if (game.engineIntervalId !== undefined) {
         throw new WsException('이미 게임이 시작되었습니다.');
       }
@@ -65,7 +61,7 @@ export class GameGateway {
   }
 
   @SubscribeMessage('move-bar')
-  movePlayerBar(@ConnectedSocket() socket: Socket, @MessageBody() { gameId, y }: MoveBarDto) {
+  movePlayerBar(@ConnectedSocket() socket: Socket, @MessageBody() { gameId, y }: MoveBarDto): void {
     const game = this.gameRepository.find(gameId);
     if (game === undefined) {
       throw new WsException('게임이 존재하지 않습니다.');
@@ -85,15 +81,15 @@ export class GameGateway {
    *
    * @param gameId
    */
-  broadcastGameStart(gameId: string) {
+  broadcastGameStart(gameId: string): void {
     this.server.to(gameId).emit('game-start', { gameId });
   }
 
-  broadcastGameData(gamedata: GameData) {
+  broadcastGameData(gamedata: GameData): void {
     this.server.to(gamedata.id).emit('game-data', gamedata);
   }
 
-  broadcastGameEnd(gameId: string, winner: Player, loser: Player) {
+  broadcastGameEnd(gameId: string, winner: Player, loser: Player): void {
     this.server.to(gameId).emit('game-end', {
       id: gameId,
       winner: { id: winner.userId, score: winner.score },
@@ -101,7 +97,7 @@ export class GameGateway {
     });
   }
 
-  updateUserStatus(userId: number, status: Status) {
+  updateUserStatus(userId: number, status: Status): void {
     this.userStatusRepository.update(userId, { status });
     this.server.to(`user-${userId}`).emit('user-status', { id: userId, status });
   }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -41,7 +41,7 @@ export class GameGateway {
   @SubscribeMessage('game-start')
   handleGameStart(@ConnectedSocket() socket: Socket, @MessageBody() { gameId }: GameStartDto) {
     const game = this.gameRepository.find(gameId);
-    if (!game) {
+    if (game === undefined) {
       throw new WsException('게임이 존재하지 않습니다.');
     }
     const userId: number = socket.data.userId;

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
-import { GameData } from '../../../game/game-data';
+import { GameData, Player } from '@/game/game-data';
+
 import { corsOption } from '../common/option/cors.option';
 import { createWsException } from '../common/util';
 import { GameRepository } from '../repository/game.repository';
@@ -72,6 +73,14 @@ export class GameGateway {
 
   broadcastGameData(gamedata: GameData) {
     this.server.to(gamedata.id).emit('game-data', gamedata);
+  }
+
+  broadcastGameEnd(gameId: string, winner: Player, loser: Player) {
+    this.server.to(gameId).emit('game-end', {
+      id: gameId,
+      winner: { id: winner.userId, score: winner.score },
+      loser: { id: loser.userId, score: loser.score },
+    });
   }
 
   updateUserStatus(userId: number, status: string) {

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { GameHistory } from '../entity/game-history.entity';
 import { RepositoryModule } from '../repository/repository.module';
 
 import { GameController } from './game.controller';
@@ -8,7 +10,7 @@ import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 
 @Module({
-  imports: [RepositoryModule],
+  imports: [RepositoryModule, TypeOrmModule.forFeature([GameHistory])],
   providers: [GameService, GameGateway, GameEngine],
   controllers: [GameController],
 })

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GameHistory } from '../entity/game-history.entity';
+import { UserRecord } from '../entity/user-record.entity';
+import { User } from '../entity/user.entity';
 import { RepositoryModule } from '../repository/repository.module';
 
 import { GameController } from './game.controller';
@@ -10,7 +12,7 @@ import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 
 @Module({
-  imports: [RepositoryModule, TypeOrmModule.forFeature([GameHistory])],
+  imports: [RepositoryModule, TypeOrmModule.forFeature([User, UserRecord, GameHistory])],
   providers: [GameService, GameGateway, GameEngine],
   controllers: [GameController],
 })

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -6,14 +6,14 @@ import { UserRecord } from '../entity/user-record.entity';
 import { User } from '../entity/user.entity';
 import { RepositoryModule } from '../repository/repository.module';
 
+import { GameEngineService } from './game-engine.service';
 import { GameController } from './game.controller';
-import { GameEngine } from './game.engine';
 import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 
 @Module({
   imports: [RepositoryModule, TypeOrmModule.forFeature([User, UserRecord, GameHistory])],
-  providers: [GameService, GameGateway, GameEngine],
+  providers: [GameService, GameGateway, GameEngineService],
   controllers: [GameController],
 })
 export class GameModule {}

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -3,12 +3,13 @@ import { Module } from '@nestjs/common';
 import { RepositoryModule } from '../repository/repository.module';
 
 import { GameController } from './game.controller';
+import { GameEngine } from './game.engine';
 import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 
 @Module({
   imports: [RepositoryModule],
-  providers: [GameService, GameGateway],
+  providers: [GameService, GameGateway, GameEngine],
   controllers: [GameController],
 })
 export class GameModule {}

--- a/backend/src/game/game.service.spec.ts
+++ b/backend/src/game/game.service.spec.ts
@@ -25,6 +25,11 @@ describe('GameService', () => {
           provide: GameGateway,
           useValue: {
             broadcastGameStart: jest.fn(),
+            updateUserStatus: jest
+              .spyOn(GameGateway.prototype, 'updateUserStatus')
+              .mockImplementation((userId, status) => {
+                userStatusRepository.update(userId, { status });
+              }),
           },
         },
       ],
@@ -54,6 +59,8 @@ describe('GameService', () => {
       nickname: 'test2',
       isMuted: false,
     };
+
+    jest.spyOn(gameGateway, 'broadcastGameStart');
 
     const channel: Channel = new Channel('1', 'public', 'test');
     channel.users.set(1, mockUser);

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -4,7 +4,6 @@ import { ChannelRepository } from '../repository/channel.repository';
 import { GameRepository } from '../repository/game.repository';
 import { ChannelUser } from '../repository/model/channel';
 import { Game } from '../repository/model/game';
-import { UserStatusRepository } from '../repository/user-status.repository';
 
 import { GameGateway } from './game.gateway';
 
@@ -13,7 +12,6 @@ export class GameService {
   constructor(
     private readonly gameRepository: GameRepository,
     private readonly channelRepository: ChannelRepository,
-    private readonly userStatusRepository: UserStatusRepository,
     private readonly gameGateway: GameGateway,
   ) {}
 
@@ -48,10 +46,8 @@ export class GameService {
 
     const game = new Game(gameId, leftPlayer.id, rightPlayer.id);
     this.gameRepository.insert(game);
-    this.userStatusRepository.update(leftPlayer.id, { status: 'game' });
-    this.gameGateway.emitGameStatusToFriends(leftPlayer.id);
-    this.userStatusRepository.update(rightPlayer.id, { status: 'game' });
-    this.gameGateway.emitGameStatusToFriends(leftPlayer.id);
+    this.gameGateway.updateUserStatus(leftPlayer.id, 'game');
+    this.gameGateway.updateUserStatus(rightPlayer.id, 'game');
 
     channel.isInGame = true;
     this.gameGateway.broadcastGameStart(game.gameData.id);

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -54,7 +54,6 @@ export class GameService {
     this.gameGateway.emitGameStatusToFriends(leftPlayer.id);
 
     channel.isInGame = true;
-
     this.gameGateway.broadcastGameStart(game.gameData.id);
     return { message: '게임이 생성되었습니다.' };
   }

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -49,7 +49,10 @@ export class GameService {
     const game = new Game(gameId, leftPlayer.id, rightPlayer.id);
     this.gameRepository.insert(game);
     this.userStatusRepository.update(leftPlayer.id, { status: 'game' });
+    this.gameGateway.emitGameStatusToFriends(leftPlayer.id);
     this.userStatusRepository.update(rightPlayer.id, { status: 'game' });
+    this.gameGateway.emitGameStatusToFriends(leftPlayer.id);
+
     channel.isInGame = true;
 
     this.gameGateway.broadcastGameStart(game.gameData.id);

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,5 +1,6 @@
 import { ForbiddenException, Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 
+import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { ChannelRepository } from '../repository/channel.repository';
 import { GameRepository } from '../repository/game.repository';
 import { ChannelUser } from '../repository/model/channel';
@@ -15,7 +16,7 @@ export class GameService {
     private readonly gameGateway: GameGateway,
   ) {}
 
-  createGame(gameId: string, userId: number) {
+  createGame(gameId: string, userId: number): SuccessResponseDto {
     const channel = this.channelRepository.find(gameId);
     if (channel === undefined) {
       throw new NotFoundException('채널이 존재하지 않습니다.');

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,10 +1,9 @@
 import { ForbiddenException, Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 
-import { GameData } from '@/game/game-data';
-
 import { ChannelRepository } from '../repository/channel.repository';
 import { GameRepository } from '../repository/game.repository';
 import { ChannelUser } from '../repository/model/channel';
+import { Game } from '../repository/model/game';
 import { UserStatusRepository } from '../repository/user-status.repository';
 
 import { GameGateway } from './game.gateway';
@@ -18,12 +17,12 @@ export class GameService {
     private readonly gameGateway: GameGateway,
   ) {}
 
-  createGame(channelId: string, userId: number) {
-    const channel = this.channelRepository.find(channelId);
+  createGame(gameId: string, userId: number) {
+    const channel = this.channelRepository.find(gameId);
     if (channel === undefined) {
       throw new NotFoundException('채널이 존재하지 않습니다.');
     }
-    if (this.gameRepository.exist(channelId)) {
+    if (this.gameRepository.exist(gameId)) {
       throw new ConflictException('해당 채널에서 이미 진행 중인 게임이 있습니다.');
     }
 
@@ -47,13 +46,13 @@ export class GameService {
       throw new ForbiddenException('플레이어가 2명 이상이어야 게임을 시작할 수 있습니다.');
     }
 
-    const game = new GameData(channelId, leftPlayer.id, rightPlayer.id);
+    const game = new Game(gameId, leftPlayer.id, rightPlayer.id);
     this.gameRepository.insert(game);
     this.userStatusRepository.update(leftPlayer.id, { status: 'game' });
     this.userStatusRepository.update(rightPlayer.id, { status: 'game' });
     channel.isInGame = true;
 
-    this.gameGateway.broadcastGameStart(game.id);
+    this.gameGateway.broadcastGameStart(game.gameData.id);
     return { message: '게임이 생성되었습니다.' };
   }
 }

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -46,6 +46,7 @@ export class GameService {
 
     const game = new Game(gameId, leftPlayer.id, rightPlayer.id);
     this.gameRepository.insert(game);
+
     this.gameGateway.updateUserStatus(leftPlayer.id, 'game');
     this.gameGateway.updateUserStatus(rightPlayer.id, 'game');
 

--- a/backend/src/message/dto/socket/last-message-view.dto.ts
+++ b/backend/src/message/dto/socket/last-message-view.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsNotEmpty, IsNumber, Max, Min } from 'class-validator';
+import { IsDateString, IsInt, IsNotEmpty, Max, Min } from 'class-validator';
 
 import { LastMessageView } from '@/types/message/socket/last-message-view.interface';
 
@@ -8,7 +8,7 @@ export class LastMessageViewDto implements LastMessageView {
    * @example 1
    */
   @IsNotEmpty()
-  @IsNumber()
+  @IsInt()
   @Min(1)
   @Max(2147483647)
   friendId: number;

--- a/backend/src/message/dto/socket/message.dto.ts
+++ b/backend/src/message/dto/socket/message.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsNotEmpty, IsNumber, IsString, Max, MaxLength, Min } from 'class-validator';
+import { IsDateString, IsInt, IsNotEmpty, IsString, Max, MaxLength, Min } from 'class-validator';
 
 import { Message } from '@/types/message/socket';
 
@@ -8,7 +8,7 @@ export class MesssageDto implements Message {
    * @example 1
    */
   @IsNotEmpty()
-  @IsNumber()
+  @IsInt()
   @Min(1)
   @Max(2147483647)
   id: number;
@@ -18,7 +18,7 @@ export class MesssageDto implements Message {
    * @example 4
    */
   @IsNotEmpty()
-  @IsNumber()
+  @IsInt()
   @Min(1)
   @Max(2147483647)
   receiverId: number;

--- a/backend/src/repository/game.repository.ts
+++ b/backend/src/repository/game.repository.ts
@@ -1,16 +1,15 @@
-import { GameData } from '@/game/game-data';
-
+import { Game } from './model/game';
 import { Repository } from './repository.interface';
 
-export class GameRepository implements Repository<string, GameData> {
-  private readonly gameList: Map<string, GameData> = new Map<string, GameData>();
+export class GameRepository implements Repository<string, Game> {
+  private readonly gameList: Map<string, Game> = new Map<string, Game>();
 
-  insert(game: GameData): string {
-    this.gameList.set(game.id, game);
-    return game.id;
+  insert(game: Game): string {
+    this.gameList.set(game.gameData.id, game);
+    return game.gameData.id;
   }
 
-  update(id: string, partialItem: Partial<GameData>): GameData | undefined {
+  update(id: string, partialItem: Partial<Game>): Game | undefined {
     const game = this.gameList.get(id);
     if (game === undefined) {
       return undefined;
@@ -24,7 +23,7 @@ export class GameRepository implements Repository<string, GameData> {
     return this.gameList.delete(id);
   }
 
-  find(id: string): GameData | undefined {
+  find(id: string): Game | undefined {
     return this.gameList.get(id);
   }
 

--- a/backend/src/repository/model/game.ts
+++ b/backend/src/repository/model/game.ts
@@ -4,7 +4,8 @@ export class Game {
   constructor(id: string, leftPlayerId: number, rightPlayerId: number) {
     this.gameData = new GameData(id, leftPlayerId, rightPlayerId);
   }
-  intervalId?: NodeJS.Timeout;
+  engineIntervalId?: NodeJS.Timeout;
+  syncIntervalId?: NodeJS.Timeout;
   playerStarted: boolean[] = [false, false];
   gameData: GameData;
 }

--- a/backend/src/repository/model/game.ts
+++ b/backend/src/repository/model/game.ts
@@ -1,0 +1,10 @@
+import { GameData } from '@/game/game-data';
+
+export class Game {
+  constructor(id: string, leftPlayerId: number, rightPlayerId: number) {
+    this.gameData = new GameData(id, leftPlayerId, rightPlayerId);
+  }
+  intervalId?: NodeJS.Timeout;
+  playerStarted: boolean[] = [false, false];
+  gameData: GameData;
+}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -5,8 +5,9 @@ import { EntityManager, Repository } from 'typeorm';
 import { AuthService } from '../auth/auth.service';
 import { HISTORY_SIZE_PER_PAGE } from '../common/constant';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
-import { AuthStatus } from '../entity/auth.entity';
+import { Auth, AuthStatus } from '../entity/auth.entity';
 import { GameHistory } from '../entity/game-history.entity';
+import { UserRecord } from '../entity/user-record.entity';
 import { User } from '../entity/user.entity';
 
 import { UserHistoryResponseDto } from './dto/response/user-history-response.dto';
@@ -45,8 +46,9 @@ export class UserService {
     await this.checkAlreadyExistUser(myId); // user 이미 있으면 에러
     await this.checkDuplicatedNickname(nickname);
     await this.userRepository.manager.transaction(async (manager: EntityManager) => {
-      await manager.insert('users', { id: myId, nickname: nickname });
-      await manager.update('auth', { id: myId }, { status: AuthStatus.REGISTERD });
+      await manager.insert(User, { id: myId, nickname: nickname });
+      await manager.insert(UserRecord, { id: myId });
+      await manager.update(Auth, { id: myId }, { status: AuthStatus.REGISTERD });
     });
     return await this.authService.signIn(myId);
   }

--- a/game/utils.ts
+++ b/game/utils.ts
@@ -31,7 +31,7 @@ export function modifyBallDirection(ball: Ball, player: Player, direction: 1 | -
  *
  * @param game
  */
-export function checkPlayerCollision(game: GameData) {
+export function checkPlayerCollision(game: GameData): boolean {
   if (game.ball.x < CANVASE_WIDTH / 2) {
     const player = game.leftPlayer;
     if (
@@ -40,6 +40,7 @@ export function checkPlayerCollision(game: GameData) {
       game.ball.y > player.y - player.height / 2
     ) {
       modifyBallDirection(game.ball, player, 1);
+      return true;
     }
   } else {
     const player = game.rightPlayer;
@@ -49,8 +50,10 @@ export function checkPlayerCollision(game: GameData) {
       game.ball.y > player.y - player.height / 2
     ) {
       modifyBallDirection(game.ball, player, -1);
+      return true;
     }
   }
+  return false;
 }
 
 /**

--- a/game/utils.ts
+++ b/game/utils.ts
@@ -61,7 +61,7 @@ export function checkPlayerCollision(game: GameData): boolean {
  *
  * @param ball
  */
-export function checkWallcollision(ball: Ball) {
+export function checkWallCollision(ball: Ball) {
   if (ball.y - ball.radius < 0 || ball.y + ball.radius > CANVASE_HEIGHT) {
     ball.vy *= -1;
   }

--- a/types/game/bar-moved.interface.ts
+++ b/types/game/bar-moved.interface.ts
@@ -1,0 +1,4 @@
+export interface BarMoved {
+  userId: number;
+  y: number;
+}

--- a/types/game/game-end.interface.ts
+++ b/types/game/game-end.interface.ts
@@ -1,0 +1,13 @@
+export class GameEnd {
+  id: string;
+  winner: {
+    id: number;
+    nickname: string;
+    score: number;
+  };
+  loser: {
+    id: number;
+    nickname: string;
+    score: number;
+  };
+}

--- a/types/game/game-start.interface.ts
+++ b/types/game/game-start.interface.ts
@@ -1,0 +1,3 @@
+export interface GameStart {
+  gameId: string;
+}

--- a/types/game/index.ts
+++ b/types/game/index.ts
@@ -1,1 +1,2 @@
 export * from './game-start.interface';
+export * from './game-end.interface';

--- a/types/game/index.ts
+++ b/types/game/index.ts
@@ -1,2 +1,3 @@
 export * from './game-start.interface';
 export * from './game-end.interface';
+export * from './move-bar.interface';

--- a/types/game/index.ts
+++ b/types/game/index.ts
@@ -1,3 +1,4 @@
 export * from './game-start.interface';
 export * from './game-end.interface';
 export * from './move-bar.interface';
+export * from './bar-moved.interface';

--- a/types/game/index.ts
+++ b/types/game/index.ts
@@ -1,1 +1,1 @@
-export * from './request';
+export * from './game-start.interface';

--- a/types/game/move-bar.interface.ts
+++ b/types/game/move-bar.interface.ts
@@ -1,0 +1,4 @@
+export interface MoveBar {
+  gameId: string;
+  y: number;
+}

--- a/types/game/request/create-game-request.interface.ts
+++ b/types/game/request/create-game-request.interface.ts
@@ -1,3 +1,0 @@
-export interface CreateGameRequest {
-  channelId: string;
-}

--- a/types/game/request/index.ts
+++ b/types/game/request/index.ts
@@ -1,1 +1,0 @@
-export * from './create-game-request.interface';


### PR DESCRIPTION
## Summary
- 게임 시작 후 본격적인 게임 로직 실행과 클라이언트 웹소켓 처리 로직
- 서버에서 10ms 마다 실행되는 게임엔진 update
- 500ms 마다 실행되는 synchronize 를 위한 websocket event `game-data` emit
## Describe your changes
### Game model
- `GameData` 와 엔진 실행 시 필요한 메타데이터를 포함한 model 을 생성했습니다.
  - 10ms 마다 실행한 `setInterval` 의 리턴값을 `engineIntervalId`, 500ms 마다 실행한 `setInterva` 의 리턴값을 `syncIntervalId` 로 저장합니다.
  - 모든 player 가 `game-start` 를 회신했는 지 확인하는 `playerStarted` 배열을 기본값 `[false, false]` 로 저장합니다.
### Game Engine
- 10ms 마다 공을 움직이면서 벽과 player 의 bar 에 닿았는지 체크합니다. 닿았다면 `game-data` 이벤트를 `emit` 합니다.
- `checkWallCollision()` 은 클라이언트 측에서도 체크하고, 똑같은 방향으로 전환될 것이기 때문에 `game-data` 를 보내지 않고 계산만 합니다.
- 10점을 달성했을 경우 `endGame()` 을 실행해서 게임 종료 시 이루어져야 할 `User`, `UserHistory`, `UserRecord` 의 업데이트 및 Repository 들을 업데이트 하는 로직을 실행합니다다.
- 저장된 id 들을 이용해 `claerInterval()` 로 루프를 종료합니다.
### Game Events
- `move-bar`
  - 플레이어가 bar를 움직이는 이벤트가 일어난 경우로 데이터를 업데이트 하고 변경될 bar 의 정보만 `bar-moved` 로 보냅니다.
- `game-start`
  - 클라이언트에서 게임을 시작할 준비가 되었을 경우로 두 플레이어가 모두 준비할 때까지 대기합니다.
- `game-data`
  - 정기적으로 그리고 유의미한 변화가 있을 때 마다 server 측에서 `GameData` 객체를 통째로 `emit` 합니다.
### Etc
- `IsNumber()` 로 실행되던 모든 정수 검증을 위한 데코레이터들을 `IsInt()` 로 교체했습니다.
- `UserService` 의 `createUser()` 에서 누락되어있던 `UserRecord` 생성 로직을 추가했습니다.
## Issue number and link
- close #370 
- close #361 
- close #360 
- close #359 
- close #358 