### PR TITLE
✨ [Feature] Feature socket-kick event

### DIFF
--- a/backend/src/channel/channel.gateway.ts
+++ b/backend/src/channel/channel.gateway.ts
@@ -15,10 +15,12 @@ import { corsOption } from '../common/option/cors.option';
 import { createWsException } from '../common/util';
 import { InvisibleChannelRepository } from '../repository/invisible-channel.repository';
 import { Channel } from '../repository/model/channel';
+import { SocketIdRepository } from '../repository/socket-id.repository';
 import { VisibleChannelRepository } from '../repository/visible-channel.repository';
 
 import { ChannelIdDto } from './dto/socket/channelId.dto';
 import ChatDto from './dto/socket/chat.dto';
+import { OperationDto } from './dto/socket/operation.dto';
 
 @UsePipes(
   new ValidationPipe({
@@ -35,10 +37,14 @@ export class ChannelGateway {
     private cacheManager: Cache,
     private readonly visibleChannelRepository: VisibleChannelRepository,
     private readonly invisibleChannelRepository: InvisibleChannelRepository,
+    private readonly socketIdRepository: SocketIdRepository,
   ) {}
 
   logger: Logger = new Logger('ChannelGateway');
 
+  /**
+   * @summary chat하는 event
+   */
   @SubscribeMessage('chat')
   async handleMessage(@ConnectedSocket() socket: Socket, @MessageBody() data: ChatDto) {
     if (data.senderId !== socket.data.userId) {
@@ -52,6 +58,44 @@ export class ChannelGateway {
       throw new WsException('채널에 참여하지 않은 유저입니다.');
     }
     socket.to(data.channelId).emit('chat', data);
+  }
+
+  /**
+   * @summary kick하는 event
+   */
+  @SubscribeMessage('kick')
+  async handleKick(@ConnectedSocket() socket: Socket, @MessageBody() data: OperationDto) {
+    const channel = this.checkExistChannel(data.channelId);
+    const user = channel.users.get(socket.data.userId);
+    if (user === undefined) {
+      throw new WsException('채널에 참여하지 않은 유저입니다.');
+    }
+    if (user.role === 'member') {
+      return { message: '킥 권한이 없습니다.' };
+    }
+    if (data.targetId === socket.data.userId) {
+      return { message: '자기 자신은 킥할 수 없습니다.' };
+    }
+    const target = channel.users.get(data.targetId);
+    if (target === undefined) {
+      throw new WsException('킥 대상이 채널에 참여하지 않은 유저입니다.');
+    }
+    if (target.role === 'owner') {
+      return { message: '채널 오너는 킥할 수 없습니다.' };
+    } // 여기까지 오면 user.role >= target.role
+    if (channel.isInGame === true && target.isPlayer === true) {
+      return { message: '게임 중인 유저는 킥할 수 없습니다.' };
+    }
+
+    channel.users.delete(data.targetId);
+    this.cacheManager.del(`mute-${data.targetId}`);
+    this.emitChannel(data.channelId, 'kicked', { userId: data.targetId });
+
+    const targetSocketId = this.socketIdRepository.find(data.targetId)?.socketId;
+    if (targetSocketId === undefined) {
+      throw new WsException('소켓 아이디를 찾을 수 없습니다.');
+    }
+    this.server.in(targetSocketId).socketsLeave(data.channelId);
   }
 
   /**

--- a/backend/src/channel/dto/socket/operation.dto.ts
+++ b/backend/src/channel/dto/socket/operation.dto.ts
@@ -1,0 +1,22 @@
+import { IsInt, IsString, Length, Max, Min } from 'class-validator';
+
+import { Operation } from '@/types/channel/socket';
+
+export class OperationDto implements Operation {
+  /**
+   * @description 채널 아이디
+   * @example 4
+   */
+  @IsString()
+  @Length(21, 21)
+  channelId: string;
+
+  /**
+   * @description 채팅 보낸 사람 아이디
+   * @example 4
+   */
+  @IsInt()
+  @Min(1)
+  @Max(2147483647)
+  targetId: number;
+}

--- a/types/channel/socket/index.ts
+++ b/types/channel/socket/index.ts
@@ -2,3 +2,4 @@ export * from './chat.interface';
 export * from './member-info.interface';
 export * from './channelId.interface';
 export * from './userId.interface';
+export * from './operation.interface';

--- a/types/channel/socket/operation.interface.ts
+++ b/types/channel/socket/operation.interface.ts
@@ -1,0 +1,4 @@
+export interface Operation {
+  channelId: string;
+  targetId: number;
+}


### PR DESCRIPTION
## Summary
- `kick` 하는 이벤트 추가했습니다. 

## Describe your changes
- `kick` 했을 때의 로직은  다음과 같습니다. 
     1. 존재하는 채널인지 확인한다.
     2. 유저가 채널에 존재하는 사람인지, 킥 권한이 있는 사람인지 확인한다. 
     3. 타겟이 채널에 존재하는 사람인지, 누구에게도 킥 당할 수 없는 사람은 아닌지 확인한다. (오너, 게임중)
     4. 유저가 타겟을 킥할 수 있는 지 확인한다.
     5. 유저를 방에서 내보내는 서버 내부 로직 구현
         1. `channel.users`에서 삭제한다. 
         2. `mute 중` 이면 `캐시`에서 삭제한다. 
    6. kick 당한 유저 포함, 채널 내 다른 유저들에게  `kicked` 이벤트를 보낸다.
    7. `소켓 room`에서 삭제한다. 

- 유저와 타겟유저의 유효성을 확인하는 로직이 `kick`, `ban`, `mute` 가 모두 똑같아서 모든 `Operation`에 대해서 확인받고 나면 공통함수로 빼보도록 하겠습니다. 
- Operation `kick`, `ban`, `mute` 모두 클라이언트에서 오는 dto가 동일하여 OperationDto로 이름짓고 공통으로 사용하려고 합니다. 

## Issue number and link
- close #377 