### PR TITLE
✨ [Feature] Modify game start event data type

### DIFF
--- a/backend/src/game/dto/player-ready.ts
+++ b/backend/src/game/dto/player-ready.ts
@@ -1,8 +1,8 @@
 import { IsString, Length } from 'class-validator';
 
-import { GameStart } from '@/types/game';
+import { PlayerReady } from '@/types/game';
 
-export class GameStartDto implements GameStart {
+export class PlayerReadyDto implements PlayerReady {
   @IsString()
   @Length(21, 21)
   gameId: string;

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -4,7 +4,7 @@ import { ApiConflictResponse, ApiForbiddenResponse, ApiOperation } from '@nestjs
 import { ExtractUserId } from '../common/decorator/extract-user-id.decorator';
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 
-import { GameStartDto } from './dto/game-start.dto';
+import { PlayerReadyDto } from './dto/player-ready';
 import { GameService } from './game.service';
 
 @Controller('game')
@@ -16,7 +16,7 @@ export class GameController {
   @ApiConflictResponse({ description: '해당 채널에서 이미 진행 중인 게임이 있는 경우' })
   @HttpCode(HttpStatus.OK)
   @Post()
-  createGame(@ExtractUserId() userId: number, @Body() { gameId }: GameStartDto): SuccessResponseDto {
+  createGame(@ExtractUserId() userId: number, @Body() { gameId }: PlayerReadyDto): SuccessResponseDto {
     return this.gameService.createGame(gameId, userId);
   }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -42,7 +42,7 @@ export class GameGateway {
     private readonly gameEngine: GameEngineService,
   ) {}
 
-  @SubscribeMessage('game-ready')
+  @SubscribeMessage('player-ready')
   handleGameStart(@ConnectedSocket() socket: Socket, @MessageBody() { gameId }: PlayerReadyDto): void {
     const game = this.gameRepository.find(gameId);
     if (game === undefined) {

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -9,11 +9,12 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
-import { BarMoved } from '@/types/game';
+import { MemberInfo } from '@/types/channel';
+import { BarMoved, GameEnd, GameStart } from '@/types/game';
+import { UserStatus } from '@/types/user';
 
 import { GameData, Player } from '@/game/game-data';
 
-import { UserStatus } from '../../../types/user';
 import { corsOption } from '../common/option/cors.option';
 import { createWsException } from '../common/util';
 import { GameRepository } from '../repository/game.repository';
@@ -85,9 +86,9 @@ export class GameGateway {
    *
    * @param gameId
    */
-  broadcastGameStart(gameId: string): void {
-    //const gameStart: PlayerReady = { gameId };
-    this.server.to(gameId).emit('game-ready');
+  broadcastGameStart(gameId: string, leftPlayer: MemberInfo, rightPlayer: MemberInfo): void {
+    const gameStart: GameStart = { gameId, leftPlayer, rightPlayer };
+    this.server.to(gameId).emit('game-ready', gameStart);
   }
 
   broadcastGameData(gamedata: GameData): void {
@@ -95,11 +96,12 @@ export class GameGateway {
   }
 
   broadcastGameEnd(gameId: string, winner: Player, loser: Player): void {
-    this.server.to(gameId).emit('game-end', {
+    const gameEnd: GameEnd = {
       id: gameId,
       winner: { id: winner.userId, score: winner.score },
       loser: { id: loser.userId, score: loser.score },
-    });
+    };
+    this.server.to(gameId).emit('game-end', gameEnd);
   }
 
   updateUserStatus(userId: number, status: Status): void {

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -42,7 +42,7 @@ export class GameGateway {
     private readonly gameEngine: GameEngineService,
   ) {}
 
-  @SubscribeMessage('game-start')
+  @SubscribeMessage('game-ready')
   handleGameStart(@ConnectedSocket() socket: Socket, @MessageBody() { gameId }: PlayerReadyDto): void {
     const game = this.gameRepository.find(gameId);
     if (game === undefined) {
@@ -88,7 +88,7 @@ export class GameGateway {
    */
   broadcastGameStart(gameId: string, leftPlayer: MemberInfo, rightPlayer: MemberInfo): void {
     const gameStart: GameStart = { gameId, leftPlayer, rightPlayer };
-    this.server.to(gameId).emit('game-ready', gameStart);
+    this.server.to(gameId).emit('game-start', gameStart);
   }
 
   broadcastGameData(gamedata: GameData): void {

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,5 +1,7 @@
 import { ForbiddenException, Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 
+import { MemberInfo } from '@/types/channel';
+
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
 import { GameRepository } from '../repository/game.repository';
 import { InvisibleChannelRepository } from '../repository/invisible-channel.repository';
@@ -54,7 +56,19 @@ export class GameService {
     this.gameGateway.updateUserStatus(rightPlayer.id, 'game');
 
     channel.isInGame = true;
-    this.gameGateway.broadcastGameStart(game.gameData.id);
+    const leftMemberInfo: MemberInfo = {
+      userId: leftPlayer.id,
+      nickname: leftPlayer.nickname,
+      image: leftPlayer.image,
+      role: leftPlayer.role,
+    };
+    const rightMemberInfo: MemberInfo = {
+      userId: rightPlayer.id,
+      nickname: rightPlayer.nickname,
+      image: rightPlayer.image,
+      role: rightPlayer.role,
+    };
+    this.gameGateway.broadcastGameStart(game.gameData.id, leftMemberInfo, rightMemberInfo);
     return { message: '게임이 생성되었습니다.' };
   }
 }

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,10 +1,11 @@
 import { ForbiddenException, Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 
 import { SuccessResponseDto } from '../common/dto/success-response.dto';
-import { ChannelRepository } from '../repository/channel.repository';
 import { GameRepository } from '../repository/game.repository';
+import { InvisibleChannelRepository } from '../repository/invisible-channel.repository';
 import { ChannelUser } from '../repository/model/channel';
 import { Game } from '../repository/model/game';
+import { VisibleChannelRepository } from '../repository/visible-channel.repository';
 
 import { GameGateway } from './game.gateway';
 
@@ -12,13 +13,14 @@ import { GameGateway } from './game.gateway';
 export class GameService {
   constructor(
     private readonly gameRepository: GameRepository,
-    private readonly channelRepository: ChannelRepository,
+    private readonly visibleChannelRepository: VisibleChannelRepository,
+    private readonly invisibleChannelRepository: InvisibleChannelRepository,
     private readonly gameGateway: GameGateway,
   ) {}
 
   createGame(gameId: string, userId: number): SuccessResponseDto {
-    const channel = this.channelRepository.find(gameId);
-    if (channel === undefined) {
+    let channel = this.visibleChannelRepository.find(gameId);
+    if (channel === undefined && (channel = this.invisibleChannelRepository.find(gameId)) === undefined) {
       throw new NotFoundException('채널이 존재하지 않습니다.');
     }
     if (this.gameRepository.exist(gameId)) {

--- a/types/game/game-end.interface.ts
+++ b/types/game/game-end.interface.ts
@@ -2,12 +2,10 @@ export interface GameEnd {
   id: string;
   winner: {
     id: number;
-    nickname: string;
     score: number;
   };
   loser: {
     id: number;
-    nickname: string;
     score: number;
   };
 }

--- a/types/game/game-start.interface.ts
+++ b/types/game/game-start.interface.ts
@@ -1,3 +1,0 @@
-export interface GameStart {
-  gameId: string;
-}

--- a/types/game/game-start.interface.ts
+++ b/types/game/game-start.interface.ts
@@ -1,0 +1,7 @@
+import { MemberInfo } from '../channel';
+
+export interface GameStart {
+  gameId: string;
+  leftPlayer: MemberInfo;
+  rightPlayer: MemberInfo;
+}

--- a/types/game/index.ts
+++ b/types/game/index.ts
@@ -1,4 +1,4 @@
-export * from './game-start.interface';
+export * from './player-ready.interface';
 export * from './game-end.interface';
 export * from './move-bar.interface';
 export * from './bar-moved.interface';

--- a/types/game/index.ts
+++ b/types/game/index.ts
@@ -2,3 +2,4 @@ export * from './player-ready.interface';
 export * from './game-end.interface';
 export * from './move-bar.interface';
 export * from './bar-moved.interface';
+export * from './game-start.interface';

--- a/types/game/player-ready.interface.ts
+++ b/types/game/player-ready.interface.ts
@@ -1,0 +1,3 @@
+export interface PlayerReady {
+  gameId: string;
+}


### PR DESCRIPTION
## Summary
- game start  POST 요청 시 channel 을 못찾던 문제 수정
- `game-start` event 타입 수정
## Describe your changes
- `gameService` 에서 `injection` 받던 객체를 `ChannelRepository`-> `InvisibleChannelRepository`, `VisibleChannelRepository` 로 변경했습니다.
- `start-game` (client -> server) 의 이름이 `player-ready` 로 변경되고 타입 이름도 변경되었습니다.
- `start-game` (server -> client) 의 emit data type 이  left, right player 의 `MemberInfo`를 포함하도록 수정되었습니다.

## Issue number and link
- close #404 
- close #402 