### PR TITLE
:hammer: [Refactor] Move leave channel function to connection gateway

### DIFF
--- a/backend/src/channel/channel.module.ts
+++ b/backend/src/channel/channel.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { MUTE_EXPIRES_IN } from '../common/constant';
+import { ConnectionModule } from '../connection/connection.module';
 import { Friendship } from '../entity/friendship.entity';
 import { User } from '../entity/user.entity';
 import { RepositoryModule } from '../repository/repository.module';
@@ -16,6 +17,7 @@ import { ChannelService } from './channel.service';
     RepositoryModule,
     TypeOrmModule.forFeature([User, Friendship]),
     CacheModule.register({ store: 'memory', ttl: MUTE_EXPIRES_IN }),
+    ConnectionModule,
   ],
   controllers: [ChannelController],
   providers: [ChannelService, ChannelGateway],

--- a/backend/src/connection/connection.gateway.ts
+++ b/backend/src/connection/connection.gateway.ts
@@ -6,9 +6,12 @@ import {
   OnGatewayDisconnect,
   WebSocketGateway,
   WebSocketServer,
+  WsException,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { Repository } from 'typeorm';
+
+import { Channel } from 'src/repository/model/channel';
 
 import { corsOption } from '../common/option/cors.option';
 import { AppConfigService } from '../config/app/configuration.service';
@@ -56,8 +59,11 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
 
   handleDisconnect(@ConnectedSocket() socket: Socket): void {
     const userId: number = socket.data.userId;
-    this.leaveChannel(userId);
+    const channel = this.findJoinedChannel(userId);
 
+    if (channel !== undefined) {
+      this.leaveChannel(userId, channel, socket);
+    }
     this.userStatusRepository.delete(userId);
     this.socketIdRepository.delete(userId);
 
@@ -66,6 +72,27 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
 
     console.log('WebSocketServer Disconnect');
     console.log(userId, 'is disconnected');
+  }
+
+  /**
+   * @description 채널 나가기 (channel.gateway에서도 사용)
+   * @param userId 채널을 떠난 user 의 id
+   * @param channel 떠난 채널
+   * @param socket 떠난 user 의 socket
+   */
+  leaveChannel(userId: number, channel: Channel, socket: Socket): void {
+    if (channel.users.delete(userId) === false) {
+      throw new WsException('채널에 참여하지 않은 유저입니다.');
+    }
+    if (channel.users.size === 0) {
+      if (channel.mode === 'private') {
+        this.invisibleChannelRepository.delete(channel.id);
+      } else {
+        this.visibleChannelRepository.delete(channel.id);
+      }
+    }
+    socket.leave(channel.id);
+    this.server.to(channel.id).emit('user-left-channel', { userId });
   }
 
   // SECTION: private
@@ -126,17 +153,16 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
   }
 
   /**
-   * channel 에 들어가 있는 상태라면 channel의 users 에서 user 를 제거한다.
-   *
-   * @param userId
+   * @description 가입된 채널을 찾아서 반환한다.
+   * @returns 가입된 채널이 없으면 undefined 를 반환한다.
    */
-  private leaveChannel(userId: number): void {
+  private findJoinedChannel(userId: number): Channel | undefined {
     const channels = [...this.visibleChannelRepository.findAll(), ...this.invisibleChannelRepository.findAll()];
 
     for (const channel of channels) {
       if (channel.users.has(userId)) {
-        channel.users.delete(userId);
-        return;
+        // this.leaveSocketRoom(userId, channel);
+        return channel;
       }
     }
   }

--- a/backend/src/connection/connection.gateway.ts
+++ b/backend/src/connection/connection.gateway.ts
@@ -11,12 +11,11 @@ import {
 import { Server, Socket } from 'socket.io';
 import { Repository } from 'typeorm';
 
-import { Channel } from 'src/repository/model/channel';
-
 import { corsOption } from '../common/option/cors.option';
 import { AppConfigService } from '../config/app/configuration.service';
 import { Friendship } from '../entity/friendship.entity';
 import { InvisibleChannelRepository } from '../repository/invisible-channel.repository';
+import { Channel } from '../repository/model/channel';
 import { Status } from '../repository/model/user-status';
 import { SocketIdRepository } from '../repository/socket-id.repository';
 import { UserStatusRepository } from '../repository/user-status.repository';

--- a/backend/src/connection/connection.gateway.ts
+++ b/backend/src/connection/connection.gateway.ts
@@ -160,7 +160,6 @@ export class ConnectionGateway implements OnGatewayConnection, OnGatewayDisconne
 
     for (const channel of channels) {
       if (channel.users.has(userId)) {
-        // this.leaveSocketRoom(userId, channel);
         return channel;
       }
     }


### PR DESCRIPTION
## Summary
- 기존 channel gateway에 있던 `leaveChannel` 함수를 공통으로 사용하기 위해 함수 분리

## Describe your changes
- connection gateway `disconnect`, channel에서 `kick`, `ban`에서도 채널을 나가는 함수가 필요함
- connection gateway에 leaveChannel 함수 생성
- `socket` 파라미터 대신 `SocketIdRepository`에서 `socket` find해서 `user-left-channel` event emit하는 방법도 있는데 어차피 socket 객체를 가지고 있어서 socket으로 넘겼습니다

## Issue number and link
- close #384 
- close #400 