### PR TITLE
✨ [Feature] Achievement about friend

### DIFF
--- a/backend/src/achievement/achievement.module.ts
+++ b/backend/src/achievement/achievement.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Achievement } from '../entity/achievement.entity';
+
+import { AchievementService } from './achievement.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Achievement])],
+  providers: [AchievementService],
+  exports: [AchievementService],
+})
+export class AchievementModule {}

--- a/backend/src/achievement/achievement.service.ts
+++ b/backend/src/achievement/achievement.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Achievement } from '../entity/achievement.entity';
+
+/**
+ * 1 : 첫 승리					// 첫 승리 축하드립니다!!
+ * 2 : 승리 100회				// 승리 100회 달성!!
+ * 3 : 총 게임 횟수 42회		// 게임을 42!!
+ * 4 : 패배 횟수 42회			// 패배도 42!!
+ * 5 : 첫 친구 만들어 봤을 때	// 드디어 친구가 생겼어요!!
+ * 6 : 친구 10명 				// 인싸로 가는 첫 걸음!!
+ * 7 : 친구 42명 				// 당신은 마당발!!
+ */
+
+@Injectable()
+export class AchievementService {
+  constructor(
+    @InjectRepository(Achievement)
+    private readonly achievementRepository: Repository<Achievement>,
+  ) {}
+
+  // SECTION: public
+  getFriendAchievement(userId: number, count: number): void {
+    if (count === 1) {
+      this.achievementRepository.save({ user: { id: userId }, achievement: 5 });
+    } else if (count == 10) {
+      this.achievementRepository.save({ user: { id: userId }, achievement: 6 });
+    } else if (count == 42) {
+      this.achievementRepository.save({ user: { id: userId }, achievement: 7 });
+    }
+  }
+}

--- a/backend/src/achievement/achievement.service.ts
+++ b/backend/src/achievement/achievement.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager } from 'typeorm';
 
 import { Achievement } from '../entity/achievement.entity';
 
@@ -16,19 +15,14 @@ import { Achievement } from '../entity/achievement.entity';
 
 @Injectable()
 export class AchievementService {
-  constructor(
-    @InjectRepository(Achievement)
-    private readonly achievementRepository: Repository<Achievement>,
-  ) {}
-
   // SECTION: public
-  getFriendAchievement(userId: number, count: number): void {
+  getFriendAchievement(userId: number, count: number, manager: EntityManager): void {
     if (count === 1) {
-      this.achievementRepository.save({ user: { id: userId }, achievement: 5 });
+      manager.save(Achievement, { user: { id: userId }, achievement: 5 });
     } else if (count == 10) {
-      this.achievementRepository.save({ user: { id: userId }, achievement: 6 });
+      manager.save(Achievement, { user: { id: userId }, achievement: 6 });
     } else if (count == 42) {
-      this.achievementRepository.save({ user: { id: userId }, achievement: 7 });
+      manager.save(Achievement, { user: { id: userId }, achievement: 7 });
     }
   }
 }

--- a/backend/src/achievement/achievement.service.ts
+++ b/backend/src/achievement/achievement.service.ts
@@ -16,13 +16,13 @@ import { Achievement } from '../entity/achievement.entity';
 @Injectable()
 export class AchievementService {
   // SECTION: public
-  getFriendAchievement(userId: number, count: number, manager: EntityManager): void {
+  async getFriendAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
     if (count === 1) {
-      manager.save(Achievement, { user: { id: userId }, achievement: 5 });
-    } else if (count == 10) {
-      manager.save(Achievement, { user: { id: userId }, achievement: 6 });
-    } else if (count == 42) {
-      manager.save(Achievement, { user: { id: userId }, achievement: 7 });
+      await manager.save(Achievement, { user: { id: userId }, achievement: 5 });
+    } else if (count === 10) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 6 });
+    } else if (count === 42) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 7 });
     }
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AchievementModule } from './achievement/achievement.module';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { UserGuard } from './auth/guard/user.guard';
@@ -40,6 +41,7 @@ import { UserModule } from './user/user.module';
     ChannelModule,
     ConnectionModule,
     GameModule,
+    AchievementModule,
   ],
   providers: [AppService, { provide: APP_GUARD, useClass: UserGuard }],
 })

--- a/backend/src/friend/friend.module.ts
+++ b/backend/src/friend/friend.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AchievementModule } from '../achievement/achievement.module';
 import { BlockedUser } from '../entity/blocked-user.entity';
 import { Friendship } from '../entity/friendship.entity';
 import { MessageView } from '../entity/message-view.entity';
@@ -12,7 +13,11 @@ import { FriendGateway } from './friend.gateway';
 import { FriendService } from './friend.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Friendship, BlockedUser, MessageView, User]), RepositoryModule],
+  imports: [
+    TypeOrmModule.forFeature([Friendship, BlockedUser, MessageView, User]),
+    RepositoryModule,
+    AchievementModule,
+  ],
   controllers: [FriendController],
   providers: [FriendService, FriendGateway],
   exports: [FriendGateway],


### PR DESCRIPTION
## Summary
- 친구 관련 업적 구현했습니다. 

## Describe your changes
- 친구 요청을 수락할 때 진짜 친구가 되는데요. 이때 매번 sender와 receiver의 친구 수를 세는 함수 `checkFriendLimit`가 있어서 이 함수가 `count값`을 return 하도록 한 후 이 값을 사용해서 업적을 줄 수 있도록 했습니다. 
- 다만 친구요청을 정말 수락해서 `db`에 넣기 전에 친구 수를 세기 때문에 업적을 주는 함수 `getFriendAchievement`에 파라미터로 줄 때는 `+ 1` 해서  전달했습니다.
- 친구 수락과 업적 부여를 `trasaction`으로 묶었는데요. 업적 부여가 안된다고 해서 친구 요청 수락을 없던 일로 만드는게 맞을까?라는 생각을 했는데 그래도 친구 수 10명이 되었는데 (에러로 인해) 업적 부여가 안되었을 때 처리가 더 힘들어서 그냥 `trasaction`처리 했습니다. 만일 업적 부여 코드에서 에러가 발생했을 시에는 그냥 유저가 수락을 한번 더 하는 것도 페이지 상에서 이상하지 않다고 생각했습니다.

## Issue number and link
- #461 