### PR TITLE
:sparkles: [Feature] Add achievement about game-history

### DIFF
--- a/backend/src/achievement/achievement.module.ts
+++ b/backend/src/achievement/achievement.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Achievement } from '../entity/achievement.entity';
+import { UserRecord } from '../entity/user-record.entity';
 
 import { AchievementService } from './achievement.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Achievement])],
+  imports: [TypeOrmModule.forFeature([Achievement, UserRecord])],
   providers: [AchievementService],
   exports: [AchievementService],
 })

--- a/backend/src/achievement/achievement.service.ts
+++ b/backend/src/achievement/achievement.service.ts
@@ -5,13 +5,13 @@ import { Achievement } from '../entity/achievement.entity';
 import { UserRecord } from '../entity/user-record.entity';
 
 /**
- * 1 : 첫 승리					// 첫 승리 축하드립니다!!
- * 2 : 승리 100회				// 승리 100회 달성!!
- * 3 : 총 게임 횟수 42회		// 게임을 42!!
- * 4 : 패배 횟수 42회			// 패배도 42!!
- * 5 : 첫 친구 만들어 봤을 때	// 드디어 친구가 생겼어요!!
- * 6 : 친구 10명 				// 인싸로 가는 첫 걸음!!
- * 7 : 친구 42명 				// 당신은 마당발!!
+ * 1 : 첫 승리                // 첫 승리 축하드립니다!!
+ * 2 : 승리 100회             // 승리 100회 달성!!
+ * 3 : 총 게임 횟수 42회      // 게임을 42!!
+ * 4 : 패배 횟수 42회         // 패배도 42!!
+ * 5 : 첫 친구 만들어 봤을 때 // 드디어 친구가 생겼어요!!
+ * 6 : 친구 10명              // 인싸로 가는 첫 걸음!!
+ * 7 : 친구 42명              // 당신은 마당발!!
  */
 
 @Injectable()
@@ -52,10 +52,8 @@ export class AchievementService {
     if (result === null) {
       return;
     }
-    // await this.getWinAchievement(userId, result.winCount, manager);
-    await this.getWinAchievement(userId, 1, manager);
-    // await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
-    await this.getTotalGameAchievement(userId, 42, manager);
+    await this.getWinAchievement(userId, result.winCount, manager);
+    await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
   }
 
   async checkLoserAchievement(userId: number, manager: EntityManager): Promise<void> {
@@ -63,9 +61,7 @@ export class AchievementService {
     if (result === null) {
       return;
     }
-    // await this.getLoseAchievement(userId, result.loseCount, manager);
-    await this.getLoseAchievement(userId, 42, manager);
-    // await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
-    await this.getTotalGameAchievement(userId, 42, manager);
+    await this.getLoseAchievement(userId, result.loseCount, manager);
+    await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
   }
 }

--- a/backend/src/achievement/achievement.service.ts
+++ b/backend/src/achievement/achievement.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { EntityManager } from 'typeorm';
 
 import { Achievement } from '../entity/achievement.entity';
+import { UserRecord } from '../entity/user-record.entity';
 
 /**
  * 1 : 첫 승리					// 첫 승리 축하드립니다!!
@@ -24,5 +25,47 @@ export class AchievementService {
     } else if (count === 42) {
       await manager.save(Achievement, { user: { id: userId }, achievement: 7 });
     }
+  }
+
+  async getWinAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+    if (count === 1) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 1 });
+    } else if (count === 100) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 2 });
+    }
+  }
+
+  async getLoseAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+    if (count === 42) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 4 });
+    }
+  }
+
+  async getTotalGameAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+    if (count === 42) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 3 });
+    }
+  }
+
+  async checkWinnerAchievement(userId: number, manager: EntityManager): Promise<void> {
+    const result = await manager.findOneBy(UserRecord, { user: { id: userId } });
+    if (result === null) {
+      return;
+    }
+    // await this.getWinAchievement(userId, result.winCount, manager);
+    await this.getWinAchievement(userId, 1, manager);
+    // await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
+    await this.getTotalGameAchievement(userId, 42, manager);
+  }
+
+  async checkLoserAchievement(userId: number, manager: EntityManager): Promise<void> {
+    const result = await manager.findOneBy(UserRecord, { user: { id: userId } });
+    if (result === null) {
+      return;
+    }
+    // await this.getLoseAchievement(userId, result.loseCount, manager);
+    await this.getLoseAchievement(userId, 42, manager);
+    // await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
+    await this.getTotalGameAchievement(userId, 42, manager);
   }
 }

--- a/backend/src/achievement/achievement.service.ts
+++ b/backend/src/achievement/achievement.service.ts
@@ -17,7 +17,7 @@ import { UserRecord } from '../entity/user-record.entity';
 @Injectable()
 export class AchievementService {
   // SECTION: public
-  async getFriendAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+  async checkFriendAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
     if (count === 1) {
       await manager.save(Achievement, { user: { id: userId }, achievement: 5 });
     } else if (count === 10) {
@@ -27,33 +27,13 @@ export class AchievementService {
     }
   }
 
-  async getWinAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
-    if (count === 1) {
-      await manager.save(Achievement, { user: { id: userId }, achievement: 1 });
-    } else if (count === 100) {
-      await manager.save(Achievement, { user: { id: userId }, achievement: 2 });
-    }
-  }
-
-  async getLoseAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
-    if (count === 42) {
-      await manager.save(Achievement, { user: { id: userId }, achievement: 4 });
-    }
-  }
-
-  async getTotalGameAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
-    if (count === 42) {
-      await manager.save(Achievement, { user: { id: userId }, achievement: 3 });
-    }
-  }
-
   async checkWinnerAchievement(userId: number, manager: EntityManager): Promise<void> {
     const result = await manager.findOneBy(UserRecord, { user: { id: userId } });
     if (result === null) {
       return;
     }
-    await this.getWinAchievement(userId, result.winCount, manager);
-    await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
+    await this.checkWinAchievement(userId, result.winCount, manager);
+    await this.checkTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
   }
 
   async checkLoserAchievement(userId: number, manager: EntityManager): Promise<void> {
@@ -61,7 +41,27 @@ export class AchievementService {
     if (result === null) {
       return;
     }
-    await this.getLoseAchievement(userId, result.loseCount, manager);
-    await this.getTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
+    await this.checkLoseAchievement(userId, result.loseCount, manager);
+    await this.checkTotalGameAchievement(userId, result.winCount + result.loseCount, manager);
+  }
+
+  private async checkWinAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+    if (count === 1) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 1 });
+    } else if (count === 100) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 2 });
+    }
+  }
+
+  private async checkLoseAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+    if (count === 42) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 4 });
+    }
+  }
+
+  private async checkTotalGameAchievement(userId: number, count: number, manager: EntityManager): Promise<void> {
+    if (count === 42) {
+      await manager.save(Achievement, { user: { id: userId }, achievement: 3 });
+    }
   }
 }

--- a/backend/src/friend/friend.service.ts
+++ b/backend/src/friend/friend.service.ts
@@ -146,8 +146,8 @@ export class FriendService {
     const senderFriendsCount = await this.checkFriendLimit(friendship.senderId, '상대방');
     await this.dataSource.manager.transaction(async (manager) => {
       await manager.update(Friendship, friendId, { accept: true });
-      await this.achievementService.getFriendAchievement(myId, myFriendsCount + 1, manager);
-      await this.achievementService.getFriendAchievement(friendship.senderId, senderFriendsCount + 1, manager);
+      await this.achievementService.checkFriendAchievement(myId, myFriendsCount + 1, manager);
+      await this.achievementService.checkFriendAchievement(friendship.senderId, senderFriendsCount + 1, manager);
     });
     this.friendGateway.addFriendToRoom(friendship.senderId, friendship.receiver.id);
     this.friendGateway.emitFriendAccepted(friendship);

--- a/backend/src/game/game-engine.service.ts
+++ b/backend/src/game/game-engine.service.ts
@@ -5,6 +5,7 @@ import { DataSource } from 'typeorm';
 import { Player } from '@/game/game-data';
 import { checkPlayerCollision, checkWallCollision, checkGameEnded, updateBall } from '@/game/utils';
 
+import { AchievementService } from '../achievement/achievement.service';
 import { GameHistory } from '../entity/game-history.entity';
 import { UserRecord } from '../entity/user-record.entity';
 import { User } from '../entity/user.entity';
@@ -26,6 +27,7 @@ export class GameEngineService {
     private readonly gameGateway: GameGateway,
     @InjectDataSource()
     private readonly dataSource: DataSource,
+    private readonly achievementService: AchievementService,
   ) {}
 
   logger: Logger = new Logger('GameEngine');
@@ -84,7 +86,9 @@ export class GameEngineService {
         { exp: () => `case when exp > ${point} then exp - ${point} else 0 end` },
       );
       await manager.update(UserRecord, { id: winner.userId }, { winCount: () => `winCount + 1` });
+      await this.achievementService.checkWinnerAchievement(winner.userId, manager);
       await manager.update(UserRecord, { id: loser.userId }, { loseCount: () => `loseCount + 1` });
+      await this.achievementService.checkLoserAchievement(loser.userId, manager);
     });
   }
 

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AchievementModule } from '../achievement/achievement.module';
 import { GameHistory } from '../entity/game-history.entity';
 import { UserRecord } from '../entity/user-record.entity';
 import { User } from '../entity/user.entity';
@@ -12,7 +13,7 @@ import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 
 @Module({
-  imports: [RepositoryModule, TypeOrmModule.forFeature([User, UserRecord, GameHistory])],
+  imports: [RepositoryModule, TypeOrmModule.forFeature([User, UserRecord, GameHistory]), AchievementModule],
   providers: [GameService, GameGateway, GameEngineService],
   controllers: [GameController],
 })


### PR DESCRIPTION
## Summary
- 게임 관련 업적 구현했습니다.
 * 1 : 첫 승리                // 첫 승리 축하드립니다!!
 * 2 : 승리 100회             // 승리 100회 달성!!
 * 3 : 총 게임 횟수 42회      // 게임을 42!!
 * 4 : 패배 횟수 42회         // 패배도 42!!
 
## Describe your changes
- `game-engine.service`의 `insertHistory`에서 업적 기록하고 난 후 `UserRecord`에 있는 레코드를 검색하여 `winCount` 와 `loseCount`를 통해 게임 기록 관련 업적을 부여합니다. 

## Issue number and link
- close #429 