### PR TITLE
💚 [Chore] Delete refresh event listener

### DIFF
--- a/frontend/src/pages/GameReadyPage/GameReadyPage.tsx
+++ b/frontend/src/pages/GameReadyPage/GameReadyPage.tsx
@@ -75,12 +75,6 @@ export const GameReadyPage = () => {
 
   // unload 이벤트는 브라우저가 닫히거나 페이지를 떠날 때 발생합니다.
   useEffect(() => {
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      event.returnValue = '';
-      return '';
-    };
-    window.addEventListener('beforeunload', handleBeforeUnload);
     history.pushState(null, location.href);
     window.onpopstate = function () {
       if (window.confirm('뒤로 가시겠습니까?')) {
@@ -91,7 +85,6 @@ export const GameReadyPage = () => {
       }
     };
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
       window.onpopstate = null;
     };
   }, [channelId]);


### PR DESCRIPTION
## Summary
- 새로고침 event listener 제거

## Describe your changes
- 새로고침 event listener 제거
- 새로고침 버튼의 default 행동은 제어할 수 없어서, 게임 나감 처리를 하고 "접속 중인 유저가 아닙니다." alert 띄워주는 것으로 해결

## Issue number and link
- close #536 