### PR TITLE
🐛 [BugFix] Add socket proxy

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,14 +1,24 @@
 server {
-    listen 80;
-    location / {
-        root    /app/dist;
-        index   index.html;
-        try_files $uri $uri/ /index.html;
-    }
-    location /api {
-        proxy_pass http://ghostserver:3000;
-    }
-    location /img {
-        proxy_pass http://ghostserver:3000;
-    }
+  listen 80;
+  location / {
+    root /app/dist;
+    index index.html;
+    try_files $uri $uri/ /index.html;
+  }
+  location /api {
+    proxy_pass http://ghostserver:3000;
+  }
+  location /img {
+    proxy_pass http://ghostserver:3000;
+  }
+  location /socket.io/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+
+    proxy_pass http://ghostserver:3000;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
 }


### PR DESCRIPTION
## Summary
- `nginx` config 파일에 socket.io proxy 추가

## Describe your changes
```
location /socket.io/ {
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header Host $host;

    proxy_pass http://ghostserver:3000;

    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
  }
```
추가해주었습니다. 소켓 정상작동 됩니다. 

## Issue number and link
- #575 