### PR TITLE
🔨 [Refactor] Change to distinguish users by account ID

### DIFF
--- a/backend/src/auth/strategy/ft.strategy.ts
+++ b/backend/src/auth/strategy/ft.strategy.ts
@@ -14,6 +14,7 @@ export class FtStrategy extends PassportStrategy(Strategy, 'ft') {
       callbackURL: ftAuthConfigService.url,
       profileFields: {
         // validate()에서 사용할 정보 (profile에 들어있음)
+        id: 'id',
         email: 'email',
       },
     });

--- a/backend/src/auth/strategy/ft.strategy.ts
+++ b/backend/src/auth/strategy/ft.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-42';
 
@@ -28,9 +28,6 @@ export class FtStrategy extends PassportStrategy(Strategy, 'ft') {
    * @returns  validate()에서 return한 값
    */
   async validate(accessToken: string, refreshToken: string, profile: LoginInfo): Promise<LoginInfo> {
-    if (profile.email === undefined || profile.email === null) {
-      throw new UnauthorizedException('42 email is empty');
-    }
-    return { provider: '42', email: profile.email, id: null };
+    return { provider: 'ft', email: profile.email ?? null, id: `ft-${profile.id}` };
   }
 }

--- a/backend/src/auth/strategy/google.strategy.ts
+++ b/backend/src/auth/strategy/google.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy } from 'passport-google-oauth20';
 
@@ -17,10 +17,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   }
 
   async validate(accessToken: string, refreshToken: string, profile: Profile): Promise<LoginInfo> {
-    const email = profile.emails?.[0].value;
-    if (email === undefined) {
-      throw new UnauthorizedException('Google email is empty');
-    }
-    return { provider: 'google', email, id: null };
+    const email = profile.emails?.[0].value ?? null;
+    return { provider: 'google', email, id: `google-${profile.id}` };
   }
 }

--- a/backend/src/auth/type/login-info.ts
+++ b/backend/src/auth/type/login-info.ts
@@ -1,9 +1,9 @@
+/**
+ * type for oauth login profile information
+ */
+
 export type LoginInfo = {
-  provider: '42' | 'google';
-  email: string;
-  id: number | null;
-  /**
-   * id === null -> unregistered
-   * id !== null -> registered
-   */
+  provider: 'ft' | 'google' | 'github';
+  email: string | null;
+  id: string;
 };

--- a/backend/src/config/database/configuration.service.ts
+++ b/backend/src/config/database/configuration.service.ts
@@ -18,6 +18,7 @@ export class DatabaseConfigService implements TypeOrmOptionsFactory {
       autoLoadEntities: true,
       logging: ['error', 'warn'],
       namingStrategy: new SnakeNamingStrategy(),
+      synchronize: true,
     };
   }
 }

--- a/backend/src/entity/auth.entity.ts
+++ b/backend/src/entity/auth.entity.ts
@@ -10,13 +10,13 @@ export class Auth {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ length: 320, unique: true })
-  email: string;
+  @Column({ type: 'varchar', length: 320, nullable: true })
+  email: string | null;
 
   @Column({ type: 'varchar', length: 64, nullable: true })
   password: string | null;
 
-  @Column({ type: 'varchar', length: 32, nullable: true, unique: true })
+  @Column({ type: 'varchar', length: 32, unique: true })
   accountId: string | null;
 
   @Column({ type: 'varchar', length: 320, nullable: true })


### PR DESCRIPTION
## Summary
- email -> account id 로 구분하는 역할 (unique) 변경
## Describe your changes
- `auth.entity.ts` 가 변경 되었습니다.
- signin/signup 시 select 기준을 `email` 에서 `accountId` 로 변경했습니다.
- db 를 한 번 날릴 거라서 `synchronize: true` 옵션을 다시 켜줬습니다. 다음 pr 에서 없애는 걸로..ㅎㅎ
- strategy 들도 `id` 를 포함해서 가져오도록 변경되었습니다.
## Issue number and link
- close #620 