### PR TITLE
:green_heart: chore: delete db container service for using rds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,11 @@
 services:
-  db:
-    container_name: ghostgres
-    image: postgres:15.3-alpine
-    restart: always
-    env_file:
-      - ./backend/.env
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    expose:
-      - 5432
-    networks:
-      - ghostnetwork
   server:
     container_name: ghostserver
-    depends_on:
-      - db
-    image: skdusdl8804/ghostserver
+    image: hannkim/ghostserver
     env_file:
       - ./backend/.env
     environment:
       - NODE_ENV=production
-    volumes:
-      - server_static_files:/app/backend/public
     ports:
       - 3000:3000
     networks:
@@ -31,7 +15,7 @@ services:
     container_name: ghostclient
     depends_on:
       - server
-    image: skdusdl8804/ghostclient
+    image: hannkim/ghostclient
     ports:
       - 80:80
     networks:
@@ -41,7 +25,3 @@ networks:
   ghostnetwork:
     name: ghostnetwork
     driver: bridge
-
-volumes:
-  db_data:
-  server_static_files:


### PR DESCRIPTION
## Summary
- AWS RDS 사용을 위한 db container service 삭제

## Describe your changes
- 도커 이미지 수정
- 현재 굉장히 많은 에러가 발생중.. 일단 rds 분리 후 배포 먼저 해고 이후에 디버깅 예정 ㅎ.ㅎ
  - 현재 405 Not allowed 에러 나오고 있는데 nginx 관련 에러인 거 같은데 관심있으신분 연락 주세여 (이걸 볼진 모르겠지만..ㅠ)

## Issue number and link